### PR TITLE
Fix apply leave: enable leave apply for past day leave

### DIFF
--- a/lib/data/services/leave_service.dart
+++ b/lib/data/services/leave_service.dart
@@ -32,26 +32,25 @@ class LeaveService {
     return requests.docs.map((leave) => leave.data()).toList();
   }
 
-  Future<bool> checkLeaveAlreadyApplied(
-      {required String userId,
-      required Map<DateTime, LeaveDayDuration> dateDuration}) async {
+  Future<bool> checkLeaveAlreadyApplied({
+    required String userId,
+    required Map<DateTime, LeaveDayDuration> dateDuration,
+  }) async {
     final leaves =
         await _leaveDb().where(FireStoreConst.uid, isEqualTo: userId).get();
+
     return leaves.docs
         .map((doc) => doc.data())
         .where((leave) =>
-            leave.startDate >= dateDuration.keys.first.timeStampToInt &&
-            leave.endDate <= dateDuration.keys.last.timeStampToInt &&
             leave.status != LeaveStatus.rejected &&
             leave.status != LeaveStatus.cancelled)
-        .where((leave) => leave
-            .getDateAndDuration()
-            .entries
-            .map((leaveDay) => dateDuration.entries
-                .map((selectedDay) => leaveDay == selectedDay)
-                .isNotEmpty)
-            .isNotEmpty)
-        .isNotEmpty;
+        .where((leave) {
+      final leaveDuration = leave.getDateAndDuration();
+      return leaveDuration.entries.any((existLeaveDay) => dateDuration.entries
+          .any((applyLeaveDay) =>
+              applyLeaveDay.key.isAtSameMomentAs(existLeaveDay.key) &&
+              applyLeaveDay.value == existLeaveDay.value));
+    }).isNotEmpty;
   }
 
   Future<List<Leave>> getRecentLeaves() async {

--- a/lib/ui/user/leaves/apply_leave/widget/date_selection_buttons.dart
+++ b/lib/ui/user/leaves/apply_leave/widget/date_selection_buttons.dart
@@ -26,9 +26,7 @@ class LeaveRequestDateSelection extends StatelessWidget {
                   .user_leaves_apply_leave_start_tag,
               onPress: () async {
                 DateTime? date = await pickDate(
-                    context: context,
-                    initialDate: state.startDate,
-                    onlyFutureDateSelection: true);
+                    context: context, initialDate: state.startDate);
                 bloc.add(ApplyLeaveStartDateChangeEvents(startDate: date));
               },
               date: state.startDate,
@@ -42,9 +40,7 @@ class LeaveRequestDateSelection extends StatelessWidget {
                   AppLocalizations.of(context).user_leaves_apply_leave_end_tag,
               onPress: () async {
                 DateTime? date = await pickDate(
-                    context: context,
-                    initialDate: state.endDate,
-                    onlyFutureDateSelection: true);
+                    context: context, initialDate: state.endDate);
                 bloc.add(ApplyLeaveEndDateChangeEvent(endDate: date));
               },
               date: state.endDate,

--- a/lib/ui/widget/date_time_picker.dart
+++ b/lib/ui/widget/date_time_picker.dart
@@ -3,16 +3,12 @@ import 'package:projectunity/data/core/extensions/date_time.dart';
 
 Future<DateTime?> pickDate(
     {required BuildContext context,
-    required DateTime initialDate,
-    bool onlyFutureDateSelection = false}) async {
+    required DateTime initialDate}) async {
   DateTime? pickDate = await showDatePicker(
     context: context,
     initialDate: initialDate,
     firstDate: DateTime(1990),
     lastDate: DateTime(DateTime.now().futureDateSelectionYear),
-    selectableDayPredicate: (day) => onlyFutureDateSelection
-        ? day.isAfter(DateTime.now().subtract(const Duration(days: 1)))
-        : true,
   );
   return pickDate;
 }


### PR DESCRIPTION
### Purpose
 - User should be able to apply leave for past days
 - Fix user not able to apply leave for other half if user already applied for another half.

### Summary of Changes
 - Enable leave apply for past days.
 - Fix user not able to apply leave for other half if user already applied for another half.

### Conformity
- [x] Followed [git guidelines](https://github.com/canopas/flutter-developer-roadmap/blob/main/GitGuideline.md) for creating commit messages and Merge Request guidelines.
- [x] Self-approved the MR - reviewed the MR as a reviewer and gave it self-approval if everything is ok. If not, made the required changes.
- [x] Ensured that the MR satisfies all specified requirements in the ticket, including bug fixes and new features.
- [x] Provided test steps, including steps to reproduce the issue or test the new functionality, ensuring other team members can verify the changes.
- [x] Added/Updated proper code comments to make it easy-to-understand for other developers.
- [x] Reused code (if the same code was written twice, made it common and reused it at both places).
- [x] Removed unused or commented code if not required.
- [x] Ensured proper Dart naming conventions were used for variables, classes, and methods.
- [x] Localized user-facing strings.
- [x] Included screenshots/videos of behavior changes: Provided visual evidence of any changes to UI or behavior for easier review and understanding in the MR description.
- [x] Implemented proper error handling: Ensured that the code anticipated and handled potential errors and edge cases gracefully.
- [x] Avoided introducing technical debt: If the MR introduces technical debt, created and linked appropriate tickets for future resolution.
- [x] Included relevant unit tests: Wrote unit tests that focused on testing behavior and functionality, rather than merely covering lines of code.
- [x] Ensured code was performant and scalable: Verified that the changes did not introduce performance issues or bottlenecks and could scale as needed.
- [x] Ensured comments were up-to-date and relevant to the code to describe complex logic and to add understanding for other developers.
- [x] Marked the MR as ready before submitting it for review.
