### PR TITLE
Sign out from current space

### DIFF
--- a/lib/data/di/service_locator.config.dart
+++ b/lib/data/di/service_locator.config.dart
@@ -173,6 +173,7 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i22.UserStateNotifier>(),
           gh<_i23.AccountService>(),
           gh<_i27.EmployeeService>(),
+          gh<_i25.AuthService>(),
         ));
     gh.lazySingleton<_i30.LeaveService>(() => _i30.LeaveService(
           gh<_i22.UserStateNotifier>(),
@@ -262,7 +263,6 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i22.UserStateNotifier>(),
           gh<_i23.AccountService>(),
           gh<_i27.EmployeeService>(),
-          gh<_i25.AuthService>(),
         ));
     gh.factory<_i50.EmployeeDetailBloc>(() => _i50.EmployeeDetailBloc(
           gh<_i23.AccountService>(),

--- a/lib/data/l10n/app_en.arb
+++ b/lib/data/l10n/app_en.arb
@@ -366,6 +366,15 @@
     }
   },
 
+  "sign_out_from_text":"Sign out from {text}",
+  "@sign_out_from_text":{
+    "placeholders":{
+      "text":{
+        "type":"String"
+      }
+    }
+  },
+
   "employee_details_leaves_title":"{name}'s Leaves",
   "@employee_details_leaves_title":{
     "placeholders":{

--- a/lib/ui/shared/appbar_drawer/drawer/app_drawer.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/app_drawer.dart
@@ -13,7 +13,6 @@ import '../../../../data/configs/text_style.dart';
 import '../../../../data/core/utils/bloc_status.dart';
 import '../../../../data/di/service_locator.dart';
 import '../../../../data/provider/user_state.dart';
-import '../../../widget/app_dialog.dart';
 import '../../../widget/circular_progress_indicator.dart';
 import 'package:flutter_gen/gen_l10n/app_localization.dart';
 import 'bloc/app_drawer_bloc.dart';
@@ -43,9 +42,9 @@ class _AppDrawerState extends State<AppDrawer> {
           context.pop();
           showSnackBar(context: context, error: state.error);
         } else if (state.changeSpaceStatus == Status.success) {
-          try{
+          try {
             context.pop();
-          }catch (_){}
+          } catch (_) {}
         }
       },
       child: Container(
@@ -70,9 +69,13 @@ class _AppDrawerState extends State<AppDrawer> {
                   currentEmployee: userManager.employee,
                   currentSpace: userManager.currentSpace!,
                 ),
-                SpaceList(userEmail: userManager.userEmail!,currentSpaceId: userManager.currentSpaceId),
+                SpaceList(
+                    userEmail: userManager.userEmail!,
+                    currentSpaceId: userManager.currentSpaceId),
                 const Divider(height: 0),
-                DrawerOptionList(isSpaceOwner: userManager.isSpaceOwner, isAdminOrHr: userManager.isAdmin || userManager.isHR),
+                DrawerOptionList(
+                    isSpaceOwner: userManager.isSpaceOwner,
+                    isAdminOrHr: userManager.isAdmin || userManager.isHR),
               ],
             ),
           ),
@@ -112,25 +115,19 @@ class DrawerOptionList extends StatelessWidget {
               title: locale.view_profile_button_tag,
               onTap: () {
                 context.pop();
-                context.goNamed(isAdminOrHr ? Routes.adminProfile : Routes.userProfile);
+                context.goNamed(
+                    isAdminOrHr ? Routes.adminProfile : Routes.userProfile);
               }),
           BlocBuilder<DrawerBloc, DrawerState>(
             buildWhen: (previous, current) =>
                 previous.signOutStatus != current.signOutStatus,
             builder: (context, state) => DrawerOption(
-                icon: Icons.logout_rounded,
-                title: locale.sign_out_tag,
-                onTap: () {
-                  showAlertDialog(
-                    context: context,
-                    actionButtonTitle: locale.sign_out_tag,
-                    onActionButtonPressed: () {
-                      context.read<DrawerBloc>().add(SignOutEvent());
-                    },
-                    title: locale.sign_out_tag,
-                    description: locale.sign_out_alert,
-                  );
-                }),
+              icon: Icons.logout_rounded,
+              title: locale.sign_out_tag,
+              onTap: () => context
+                  .read<DrawerBloc>()
+                  .add(SignOutWithCurrentSpaceEvent()),
+            ),
           ),
         ],
       ),
@@ -142,7 +139,9 @@ class SpaceList extends StatelessWidget {
   final String userEmail;
   final String? currentSpaceId;
 
-  const SpaceList({Key? key, required this.userEmail, required this.currentSpaceId}) : super(key: key);
+  const SpaceList(
+      {Key? key, required this.userEmail, required this.currentSpaceId})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {

--- a/lib/ui/shared/appbar_drawer/drawer/app_drawer.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/app_drawer.dart
@@ -95,6 +95,7 @@ class DrawerOptionList extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final userStateNotifier= getIt<UserStateNotifier>();
     final locale = AppLocalizations.of(context);
     return Padding(
       padding: const EdgeInsets.all(8.0),
@@ -118,12 +119,13 @@ class DrawerOptionList extends StatelessWidget {
                 context.goNamed(
                     isAdminOrHr ? Routes.adminProfile : Routes.userProfile);
               }),
+          
           BlocBuilder<DrawerBloc, DrawerState>(
             buildWhen: (previous, current) =>
                 previous.signOutStatus != current.signOutStatus,
             builder: (context, state) => DrawerOption(
               icon: Icons.logout_rounded,
-              title: locale.sign_out_tag,
+              title: locale.sign_out_from_text(userStateNotifier.currentSpace?.name ?? "current space"),
               onTap: () => context
                   .read<DrawerBloc>()
                   .add(SignOutWithCurrentSpaceEvent()),

--- a/lib/ui/shared/appbar_drawer/drawer/app_drawer.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/app_drawer.dart
@@ -128,7 +128,7 @@ class DrawerOptionList extends StatelessWidget {
               title: locale.sign_out_from_text(userStateNotifier.currentSpace!.name),
               onTap: () => context
                   .read<DrawerBloc>()
-                  .add(SignOutFromSpace()),
+                  .add(SignOutFromSpaceEvent()),
             ),
           ),
         ],

--- a/lib/ui/shared/appbar_drawer/drawer/app_drawer.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/app_drawer.dart
@@ -125,10 +125,10 @@ class DrawerOptionList extends StatelessWidget {
                 previous.signOutStatus != current.signOutStatus,
             builder: (context, state) => DrawerOption(
               icon: Icons.logout_rounded,
-              title: locale.sign_out_from_text(userStateNotifier.currentSpace?.name ?? "current space"),
+              title: locale.sign_out_from_text(userStateNotifier.currentSpace!.name),
               onTap: () => context
                   .read<DrawerBloc>()
-                  .add(SignOutWithCurrentSpaceEvent()),
+                  .add(SignOutFromSpace()),
             ),
           ),
         ],

--- a/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_bloc.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_bloc.dart
@@ -22,7 +22,7 @@ class DrawerBloc extends Bloc<DrawerEvents, DrawerState> {
       : super(const DrawerState()) {
     on<FetchSpacesEvent>(_fetchSpaces);
     on<ChangeSpaceEvent>(_changeSpace);
-    on<SignOutFromSpace>(_signOutFromCurrentSpace);
+    on<SignOutFromSpaceEvent>(_signOutFromCurrentSpace);
   }
 
   Future<void> _fetchSpaces(
@@ -63,7 +63,7 @@ class DrawerBloc extends Bloc<DrawerEvents, DrawerState> {
   }
 
   Future<void> _signOutFromCurrentSpace(
-      SignOutFromSpace event, Emitter<DrawerState> emit) async {
+      SignOutFromSpaceEvent event, Emitter<DrawerState> emit) async {
     emit(state.copyWith(signOutStatus: Status.loading));
     try {
       await _userManager.removeEmployeeWithSpace();

--- a/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_bloc.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_bloc.dart
@@ -22,7 +22,7 @@ class DrawerBloc extends Bloc<DrawerEvents, DrawerState> {
       : super(const DrawerState()) {
     on<FetchSpacesEvent>(_fetchSpaces);
     on<ChangeSpaceEvent>(_changeSpace);
-    on<SignOutWithCurrentSpaceEvent>(_signOutFromCurrentSpace);
+    on<SignOutFromSpace>(_signOutFromCurrentSpace);
   }
 
   Future<void> _fetchSpaces(
@@ -63,7 +63,7 @@ class DrawerBloc extends Bloc<DrawerEvents, DrawerState> {
   }
 
   Future<void> _signOutFromCurrentSpace(
-      SignOutWithCurrentSpaceEvent event, Emitter<DrawerState> emit) async {
+      SignOutFromSpace event, Emitter<DrawerState> emit) async {
     emit(state.copyWith(signOutStatus: Status.loading));
     try {
       await _userManager.removeEmployeeWithSpace();

--- a/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_event.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_event.dart
@@ -10,5 +10,4 @@ class ChangeSpaceEvent extends DrawerEvents {
   ChangeSpaceEvent(this.space);
 }
 
-class SignOutEvent extends DrawerEvents {
-}
+class SignOutWithCurrentSpaceEvent extends DrawerEvents {}

--- a/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_event.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_event.dart
@@ -10,4 +10,4 @@ class ChangeSpaceEvent extends DrawerEvents {
   ChangeSpaceEvent(this.space);
 }
 
-class SignOutWithCurrentSpaceEvent extends DrawerEvents {}
+class SignOutFromSpace extends DrawerEvents {}

--- a/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_event.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/bloc/app_drawer_event.dart
@@ -10,4 +10,4 @@ class ChangeSpaceEvent extends DrawerEvents {
   ChangeSpaceEvent(this.space);
 }
 
-class SignOutFromSpace extends DrawerEvents {}
+class SignOutFromSpaceEvent extends DrawerEvents {}

--- a/lib/ui/shared/appbar_drawer/drawer/widget/drawer_option.dart
+++ b/lib/ui/shared/appbar_drawer/drawer/widget/drawer_option.dart
@@ -38,7 +38,7 @@ class DrawerOption extends StatelessWidget {
               child: Text(
                 title,
                 style: AppFontStyle.bodyLarge.copyWith(color: titleColor),
-                overflow: TextOverflow.ellipsis,
+                overflow: TextOverflow.fade,
               ),
             ),
           ],

--- a/lib/ui/shared/profile/view_profile/widget/basic_detail_section.dart
+++ b/lib/ui/shared/profile/view_profile/widget/basic_detail_section.dart
@@ -22,6 +22,7 @@ class BasicDetailSection extends StatelessWidget {
           const EdgeInsets.all(primaryHorizontalSpacing).copyWith(bottom: 0),
       child: Column(children: [
         ProfileSection(employee: employee),
+        const SizedBox(height: 20),
         ContactSection(
           email: employee.email,
           phone: employee.phone,
@@ -104,7 +105,7 @@ class ContactSection extends StatelessWidget {
             ],
           ),
         ),
-        const SizedBox(height: 20),
+        const SizedBox(height: 8),
         Row(
           children: [
             const Icon(

--- a/lib/ui/space/join_space/bloc/join_space_bloc.dart
+++ b/lib/ui/space/join_space/bloc/join_space_bloc.dart
@@ -5,6 +5,7 @@ import 'package:projectunity/data/core/exception/error_const.dart';
 import 'package:projectunity/data/model/employee/employee.dart';
 import 'package:projectunity/data/provider/user_state.dart';
 import 'package:projectunity/data/services/account_service.dart';
+import 'package:projectunity/data/services/auth_service.dart';
 import 'package:projectunity/ui/space/join_space/bloc/join_space_event.dart';
 import 'package:projectunity/ui/space/join_space/bloc/join_space_state.dart';
 import '../../../../data/core/utils/bloc_status.dart';
@@ -21,14 +22,16 @@ class JoinSpaceBloc extends Bloc<JoinSpaceEvents, JoinSpaceState> {
   final SpaceService _spaceService;
   final InvitationService _invitationService;
   final AccountService accountService;
+  final AuthService _authService;
   late final List<Invitation> invitations;
 
   JoinSpaceBloc(this._invitationService, this._spaceService, this._userManager,
-      this.accountService, this._employeeService)
+      this.accountService, this._employeeService, this._authService)
       : super(const JoinSpaceState()) {
     on<JoinSpaceInitialFetchEvent>(_init);
     on<SelectSpaceEvent>(_selectSpace);
     on<JoinRequestedSpaceEvent>(_joinRequestedSpace);
+    on<SignOutEvent>(_signOut);
   }
 
   String get userEmail => _userManager.userEmail ?? "unknown";
@@ -116,5 +119,21 @@ class JoinSpaceBloc extends Bloc<JoinSpaceEvents, JoinSpaceState> {
   Invitation deleteInvitation(String spaceId) {
     return invitations
         .firstWhere((invitation) => invitation.spaceId == spaceId);
+  }
+
+  Future<void> _signOut(
+      SignOutEvent event, Emitter<JoinSpaceState> emit) async {
+    emit(state.copyWith(signOutStatus: Status.loading));
+    try {
+      bool isLogOut = await _authService.signOutWithGoogle();
+      if (isLogOut) {
+        await _userManager.removeAll();
+        emit(state.copyWith(signOutStatus: Status.success));
+      } else {
+        throw Exception(signOutError);
+      }
+    } on Exception {
+      emit(state.copyWith(error: signOutError, signOutStatus: Status.error));
+    }
   }
 }

--- a/lib/ui/space/join_space/bloc/join_space_event.dart
+++ b/lib/ui/space/join_space/bloc/join_space_event.dart
@@ -1,10 +1,6 @@
-import 'package:equatable/equatable.dart';
 import 'package:projectunity/data/model/space/space.dart';
 
-class JoinSpaceEvents extends Equatable {
-  @override
-  List<Object?> get props => [];
-}
+class JoinSpaceEvents {}
 
 class JoinSpaceInitialFetchEvent extends JoinSpaceEvents {}
 
@@ -25,3 +21,5 @@ class SelectInvitationEvent extends JoinSpaceEvents {
 
   SelectInvitationEvent({required this.invitation});
 }
+
+class SignOutEvent extends JoinSpaceEvents {}

--- a/lib/ui/space/join_space/bloc/join_space_event.dart
+++ b/lib/ui/space/join_space/bloc/join_space_event.dart
@@ -16,10 +16,4 @@ class JoinRequestedSpaceEvent extends JoinSpaceEvents {
   JoinRequestedSpaceEvent({required this.space});
 }
 
-class SelectInvitationEvent extends JoinSpaceEvents {
-  final Invocation invitation;
-
-  SelectInvitationEvent({required this.invitation});
-}
-
 class SignOutEvent extends JoinSpaceEvents {}

--- a/lib/ui/space/join_space/bloc/join_space_state.dart
+++ b/lib/ui/space/join_space/bloc/join_space_state.dart
@@ -5,6 +5,7 @@ import '../../../../data/model/space/space.dart';
 class JoinSpaceState extends Equatable {
   final Status fetchSpaceStatus;
   final Status selectSpaceStatus;
+  final Status signOutStatus;
   final List<Space> ownSpaces;
   final List<Space> requestedSpaces;
   final String? error;
@@ -12,25 +13,34 @@ class JoinSpaceState extends Equatable {
   const JoinSpaceState({
     this.selectSpaceStatus = Status.initial,
     this.fetchSpaceStatus = Status.initial,
+    this.signOutStatus = Status.initial,
     this.ownSpaces = const [],
     this.requestedSpaces = const [],
     this.error,
   });
 
   JoinSpaceState copyWith(
-          {Status? fetchSpaceStatus,
+          {Status? signOutStatus,
+          Status? fetchSpaceStatus,
           Status? selectSpaceStatus,
           List<Space>? ownSpaces,
           List<Space>? requestedSpaces,
           String? error}) =>
       JoinSpaceState(
           error: error,
+          signOutStatus: signOutStatus ?? this.signOutStatus,
           selectSpaceStatus: selectSpaceStatus ?? this.selectSpaceStatus,
           fetchSpaceStatus: fetchSpaceStatus ?? this.fetchSpaceStatus,
           requestedSpaces: requestedSpaces ?? this.requestedSpaces,
           ownSpaces: ownSpaces ?? this.ownSpaces);
 
   @override
-  List<Object?> get props =>
-      [fetchSpaceStatus, ownSpaces, requestedSpaces, error, selectSpaceStatus];
+  List<Object?> get props => [
+        fetchSpaceStatus,
+        ownSpaces,
+        requestedSpaces,
+        error,
+        selectSpaceStatus,
+        signOutStatus
+      ];
 }

--- a/lib/ui/space/join_space/join_space_screen.dart
+++ b/lib/ui/space/join_space/join_space_screen.dart
@@ -171,7 +171,7 @@ class _JoinSpaceScreenState extends State<JoinSpaceScreen> {
                                     Size(MediaQuery.of(context).size.width, 50),
                                 foregroundColor: AppColors.redColor),
                             child: Text(
-                              "Sign out from ${context.read<JoinSpaceBloc>().userEmail}",
+                              locale.sign_out_from_text(context.read<JoinSpaceBloc>().userEmail),
                               style: AppFontStyle.buttonTextStyle
                                   .copyWith(color: AppColors.redColor),
                             ),

--- a/lib/ui/space/join_space/join_space_screen.dart
+++ b/lib/ui/space/join_space/join_space_screen.dart
@@ -15,6 +15,7 @@ import 'package:projectunity/ui/widget/error_snack_bar.dart';
 import '../../../data/configs/colors.dart';
 import '../../../data/core/utils/bloc_status.dart';
 import '../../navigation/app_router.dart';
+import '../../widget/app_dialog.dart';
 
 class JoinSpacePage extends StatelessWidget {
   const JoinSpacePage({Key? key}) : super(key: key);
@@ -97,7 +98,8 @@ class _JoinSpaceScreenState extends State<JoinSpaceScreen> {
                   buildWhen: (previous, current) =>
                       current.fetchSpaceStatus == Status.success,
                   builder: (context, state) {
-                    if (state.fetchSpaceStatus == Status.loading || state.fetchSpaceStatus == Status.initial) {
+                    if (state.fetchSpaceStatus == Status.loading ||
+                        state.fetchSpaceStatus == Status.initial) {
                       return const Padding(
                         padding: EdgeInsets.all(20),
                         child: AppCircularProgressIndicator(),
@@ -148,7 +150,32 @@ class _JoinSpaceScreenState extends State<JoinSpaceScreen> {
                                       .toList(),
                                 )
                               ],
-                            )
+                            ),
+                          const SizedBox(height: 10),
+                          TextButton(
+                            onPressed: () {
+                              showAlertDialog(
+                                context: context,
+                                actionButtonTitle: locale.sign_out_tag,
+                                onActionButtonPressed: () { context
+                                    .read<JoinSpaceBloc>()
+                                    .add(SignOutEvent());
+                                  context.pop();
+                                  },
+                                title: locale.sign_out_tag,
+                                description: locale.sign_out_alert,
+                              );
+                            },
+                            style: TextButton.styleFrom(
+                                fixedSize:
+                                    Size(MediaQuery.of(context).size.width, 50),
+                                foregroundColor: AppColors.redColor),
+                            child: Text(
+                              "Sign out from ${context.read<JoinSpaceBloc>().userEmail}",
+                              style: AppFontStyle.buttonTextStyle
+                                  .copyWith(color: AppColors.redColor),
+                            ),
+                          ),
                         ],
                       );
                     }

--- a/lib/ui/space/join_space/join_space_screen.dart
+++ b/lib/ui/space/join_space/join_space_screen.dart
@@ -171,7 +171,7 @@ class _JoinSpaceScreenState extends State<JoinSpaceScreen> {
                                     Size(MediaQuery.of(context).size.width, 50),
                                 foregroundColor: AppColors.redColor),
                             child: Text(
-                              locale.sign_out_from_text(context.read<JoinSpaceBloc>().userEmail),
+                              locale.sign_out_tag,
                               style: AppFontStyle.buttonTextStyle
                                   .copyWith(color: AppColors.redColor),
                             ),

--- a/lib/ui/user/leaves/leaves_screen/user_leave_screen.dart
+++ b/lib/ui/user/leaves/leaves_screen/user_leave_screen.dart
@@ -45,7 +45,7 @@ class _UserLeaveScreenState extends State<UserLeaveScreen> {
         title: Text(AppLocalizations.of(context).leaves_tag),
       ),
       body: ListView(
-        padding: const EdgeInsets.all(16),
+        padding: const EdgeInsets.all(16).copyWith(bottom: 86),
         children: [
           const LeaveCountCard(),
           const Divider(height: 32),

--- a/lib/ui/user/members/members_screen/user_members_screen.dart
+++ b/lib/ui/user/members/members_screen/user_members_screen.dart
@@ -59,8 +59,7 @@ class _UserMembersScreenState extends State<UserMembersScreen> {
                 return const AppCircularProgressIndicator();
               } else if (state is UserEmployeesSuccessState) {
                 return ListView.separated(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: primaryVerticalSpacing),
+                    padding: const EdgeInsets.all( primaryVerticalSpacing),
                     itemBuilder: (BuildContext context, int index) {
                       Employee employee = state.employees[index];
                       return EmployeeCard(

--- a/lib/ui/widget/leave_details_widget/leave_details_header_content.dart
+++ b/lib/ui/widget/leave_details_widget/leave_details_header_content.dart
@@ -33,7 +33,7 @@ class LeaveTypeAgoTitleWithStatus extends StatelessWidget {
             children: [
               Text(
                 AppLocalizations.of(context)
-                    .leave_type_placeholder_text(leaveType.toString()),
+                    .leave_type_placeholder_text(leaveType.value.toString()),
                 style: AppFontStyle.titleDark,
               ),
               const SizedBox(height: 2),

--- a/test/unit_test/shared/drawer/drawer_test.dart
+++ b/test/unit_test/shared/drawer/drawer_test.dart
@@ -114,7 +114,7 @@ void main() {
     });
 
     test("sign out successful test with navigation test", () async {
-      bloc.add(SignOutWithCurrentSpaceEvent());
+      bloc.add(SignOutFromSpace());
       expect(
           bloc.stream,
           emitsInOrder([
@@ -127,7 +127,7 @@ void main() {
 
     test("sign out failure test", () {
       when(userStateNotifier.removeEmployeeWithSpace()).thenThrow(Exception("error"));
-      bloc.add(SignOutWithCurrentSpaceEvent());
+      bloc.add(SignOutFromSpace());
       expect(
           bloc.stream,
           emitsInOrder([

--- a/test/unit_test/shared/drawer/drawer_test.dart
+++ b/test/unit_test/shared/drawer/drawer_test.dart
@@ -114,7 +114,7 @@ void main() {
     });
 
     test("sign out successful test with navigation test", () async {
-      bloc.add(SignOutFromSpace());
+      bloc.add(SignOutFromSpaceEvent());
       expect(
           bloc.stream,
           emitsInOrder([
@@ -127,7 +127,7 @@ void main() {
 
     test("sign out failure test", () {
       when(userStateNotifier.removeEmployeeWithSpace()).thenThrow(Exception("error"));
-      bloc.add(SignOutFromSpace());
+      bloc.add(SignOutFromSpaceEvent());
       expect(
           bloc.stream,
           emitsInOrder([

--- a/test/unit_test/shared/drawer/drawer_test.dart
+++ b/test/unit_test/shared/drawer/drawer_test.dart
@@ -7,10 +7,8 @@ import 'package:projectunity/data/model/employee/employee.dart';
 import 'package:projectunity/data/model/space/space.dart';
 import 'package:projectunity/data/provider/user_state.dart';
 import 'package:projectunity/data/services/account_service.dart';
-import 'package:projectunity/data/services/auth_service.dart';
 import 'package:projectunity/data/services/employee_service.dart';
 import 'package:projectunity/data/services/space_service.dart';
-
 import 'package:projectunity/ui/shared/appbar_drawer/drawer/bloc/app_drawer_bloc.dart';
 import 'package:projectunity/ui/shared/appbar_drawer/drawer/bloc/app_drawer_event.dart';
 import 'package:projectunity/ui/shared/appbar_drawer/drawer/bloc/app_drawer_state.dart';
@@ -22,23 +20,20 @@ import 'drawer_test.mocks.dart';
   UserStateNotifier,
   EmployeeService,
   AccountService,
-  AuthService
 ])
 void main() {
   late SpaceService spaceService;
   late UserStateNotifier userStateNotifier;
   late EmployeeService employeeService;
   late AccountService accountService;
-  late AuthService authService;
   late DrawerBloc bloc;
   setUp(() {
     spaceService = MockSpaceService();
     userStateNotifier = MockUserStateNotifier();
     employeeService = MockEmployeeService();
     accountService = MockAccountService();
-    authService = MockAuthService();
     bloc = DrawerBloc(spaceService, userStateNotifier, accountService,
-        employeeService, authService);
+        employeeService);
     when(userStateNotifier.userUID).thenReturn('uid');
     when(userStateNotifier.currentSpaceId).thenReturn('sid');
     when(accountService.fetchSpaceIds(uid: 'uid'))
@@ -119,23 +114,20 @@ void main() {
     });
 
     test("sign out successful test with navigation test", () async {
-      when(authService.signOutWithGoogle())
-          .thenAnswer((_) => Future(() => true));
-      bloc.add(SignOutEvent());
+      bloc.add(SignOutWithCurrentSpaceEvent());
       expect(
           bloc.stream,
           emitsInOrder([
             const DrawerState(signOutStatus: Status.loading),
             const DrawerState(signOutStatus: Status.success),
           ]));
-      await untilCalled(userStateNotifier.removeAll());
-      verify(userStateNotifier.removeAll()).called(1);
+      await untilCalled(userStateNotifier.removeEmployeeWithSpace());
+      verify(userStateNotifier.removeEmployeeWithSpace()).called(1);
     });
 
     test("sign out failure test", () {
-      when(authService.signOutWithGoogle())
-          .thenAnswer((_) => Future(() => false));
-      bloc.add(SignOutEvent());
+      when(userStateNotifier.removeEmployeeWithSpace()).thenThrow(Exception("error"));
+      bloc.add(SignOutWithCurrentSpaceEvent());
       expect(
           bloc.stream,
           emitsInOrder([

--- a/test/unit_test/shared/drawer/drawer_test.mocks.dart
+++ b/test/unit_test/shared/drawer/drawer_test.mocks.dart
@@ -3,21 +3,20 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i9;
-import 'dart:ui' as _i11;
+import 'dart:async' as _i8;
+import 'dart:ui' as _i10;
 
 import 'package:cloud_firestore/cloud_firestore.dart' as _i2;
-import 'package:firebase_auth/firebase_auth.dart' as _i7;
+import 'package:firebase_auth/firebase_auth.dart' as _i13;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:projectunity/data/model/account/account.dart' as _i6;
 import 'package:projectunity/data/model/employee/employee.dart' as _i4;
 import 'package:projectunity/data/model/space/space.dart' as _i3;
 import 'package:projectunity/data/provider/device_info.dart' as _i5;
-import 'package:projectunity/data/provider/user_state.dart' as _i10;
-import 'package:projectunity/data/services/account_service.dart' as _i13;
-import 'package:projectunity/data/services/auth_service.dart' as _i14;
-import 'package:projectunity/data/services/employee_service.dart' as _i12;
-import 'package:projectunity/data/services/space_service.dart' as _i8;
+import 'package:projectunity/data/provider/user_state.dart' as _i9;
+import 'package:projectunity/data/services/account_service.dart' as _i12;
+import 'package:projectunity/data/services/employee_service.dart' as _i11;
+import 'package:projectunity/data/services/space_service.dart' as _i7;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -82,20 +81,10 @@ class _FakeAccount_4 extends _i1.SmartFake implements _i6.Account {
         );
 }
 
-class _FakeFirebaseAuth_5 extends _i1.SmartFake implements _i7.FirebaseAuth {
-  _FakeFirebaseAuth_5(
-    Object parent,
-    Invocation parentInvocation,
-  ) : super(
-          parent,
-          parentInvocation,
-        );
-}
-
 /// A class which mocks [SpaceService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSpaceService extends _i1.Mock implements _i8.SpaceService {
+class MockSpaceService extends _i1.Mock implements _i7.SpaceService {
   MockSpaceService() {
     _i1.throwOnMissingStub(this);
   }
@@ -117,15 +106,15 @@ class MockSpaceService extends _i1.Mock implements _i8.SpaceService {
         returnValueForMissingStub: null,
       );
   @override
-  _i9.Future<_i3.Space?> getSpace(String? spaceId) => (super.noSuchMethod(
+  _i8.Future<_i3.Space?> getSpace(String? spaceId) => (super.noSuchMethod(
         Invocation.method(
           #getSpace,
           [spaceId],
         ),
-        returnValue: _i9.Future<_i3.Space?>.value(),
-      ) as _i9.Future<_i3.Space?>);
+        returnValue: _i8.Future<_i3.Space?>.value(),
+      ) as _i8.Future<_i3.Space?>);
   @override
-  _i9.Future<_i3.Space> createSpace({
+  _i8.Future<_i3.Space> createSpace({
     String? logo,
     required String? name,
     String? domain,
@@ -144,7 +133,7 @@ class MockSpaceService extends _i1.Mock implements _i8.SpaceService {
             #ownerId: ownerId,
           },
         ),
-        returnValue: _i9.Future<_i3.Space>.value(_FakeSpace_1(
+        returnValue: _i8.Future<_i3.Space>.value(_FakeSpace_1(
           this,
           Invocation.method(
             #createSpace,
@@ -158,18 +147,18 @@ class MockSpaceService extends _i1.Mock implements _i8.SpaceService {
             },
           ),
         )),
-      ) as _i9.Future<_i3.Space>);
+      ) as _i8.Future<_i3.Space>);
   @override
-  _i9.Future<void> updateSpace(_i3.Space? space) => (super.noSuchMethod(
+  _i8.Future<void> updateSpace(_i3.Space? space) => (super.noSuchMethod(
         Invocation.method(
           #updateSpace,
           [space],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<void> deleteSpace(
+  _i8.Future<void> deleteSpace(
     String? workspaceId,
     List<String>? owners,
   ) =>
@@ -181,30 +170,30 @@ class MockSpaceService extends _i1.Mock implements _i8.SpaceService {
             owners,
           ],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<List<_i3.Space>> getSpacesOfUser(String? uid) =>
+  _i8.Future<List<_i3.Space>> getSpacesOfUser(String? uid) =>
       (super.noSuchMethod(
         Invocation.method(
           #getSpacesOfUser,
           [uid],
         ),
-        returnValue: _i9.Future<List<_i3.Space>>.value(<_i3.Space>[]),
-      ) as _i9.Future<List<_i3.Space>>);
+        returnValue: _i8.Future<List<_i3.Space>>.value(<_i3.Space>[]),
+      ) as _i8.Future<List<_i3.Space>>);
   @override
-  _i9.Future<int> getPaidLeaves({required String? spaceId}) =>
+  _i8.Future<int> getPaidLeaves({required String? spaceId}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPaidLeaves,
           [],
           {#spaceId: spaceId},
         ),
-        returnValue: _i9.Future<int>.value(0),
-      ) as _i9.Future<int>);
+        returnValue: _i8.Future<int>.value(0),
+      ) as _i8.Future<int>);
   @override
-  _i9.Future<void> updateLeaveCount({
+  _i8.Future<void> updateLeaveCount({
     required String? spaceId,
     required int? paidLeaveCount,
   }) =>
@@ -217,24 +206,24 @@ class MockSpaceService extends _i1.Mock implements _i8.SpaceService {
             #paidLeaveCount: paidLeaveCount,
           },
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 }
 
 /// A class which mocks [UserStateNotifier].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUserStateNotifier extends _i1.Mock implements _i10.UserStateNotifier {
+class MockUserStateNotifier extends _i1.Mock implements _i9.UserStateNotifier {
   MockUserStateNotifier() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i10.UserState get state => (super.noSuchMethod(
+  _i9.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i10.UserState.unknown,
-      ) as _i10.UserState);
+        returnValue: _i9.UserState.unknown,
+      ) as _i9.UserState);
   @override
   String get employeeId => (super.noSuchMethod(
         Invocation.getter(#employeeId),
@@ -277,16 +266,16 @@ class MockUserStateNotifier extends _i1.Mock implements _i10.UserStateNotifier {
         returnValueForMissingStub: null,
       );
   @override
-  _i9.Future<void> setUser(_i6.Account? user) => (super.noSuchMethod(
+  _i8.Future<void> setUser(_i6.Account? user) => (super.noSuchMethod(
         Invocation.method(
           #setUser,
           [user],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<void> setEmployeeWithSpace({
+  _i8.Future<void> setEmployeeWithSpace({
     required _i3.Space? space,
     required _i4.Employee? spaceUser,
     bool? redirect = true,
@@ -301,38 +290,38 @@ class MockUserStateNotifier extends _i1.Mock implements _i10.UserStateNotifier {
             #redirect: redirect,
           },
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<void> updateSpace(_i3.Space? space) => (super.noSuchMethod(
+  _i8.Future<void> updateSpace(_i3.Space? space) => (super.noSuchMethod(
         Invocation.method(
           #updateSpace,
           [space],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<void> removeEmployeeWithSpace() => (super.noSuchMethod(
+  _i8.Future<void> removeEmployeeWithSpace() => (super.noSuchMethod(
         Invocation.method(
           #removeEmployeeWithSpace,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<void> removeAll() => (super.noSuchMethod(
+  _i8.Future<void> removeAll() => (super.noSuchMethod(
         Invocation.method(
           #removeAll,
           [],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  void addListener(_i11.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i10.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -340,7 +329,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i10.UserStateNotifier {
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(_i11.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i10.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -368,7 +357,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i10.UserStateNotifier {
 /// A class which mocks [EmployeeService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockEmployeeService extends _i1.Mock implements _i12.EmployeeService {
+class MockEmployeeService extends _i1.Mock implements _i11.EmployeeService {
   MockEmployeeService() {
     _i1.throwOnMissingStub(this);
   }
@@ -382,7 +371,7 @@ class MockEmployeeService extends _i1.Mock implements _i12.EmployeeService {
         ),
       ) as _i2.FirebaseFirestore);
   @override
-  _i9.Future<void> addEmployeeBySpaceId({
+  _i8.Future<void> addEmployeeBySpaceId({
     required _i4.Employee? employee,
     required String? spaceId,
   }) =>
@@ -395,11 +384,11 @@ class MockEmployeeService extends _i1.Mock implements _i12.EmployeeService {
             #spaceId: spaceId,
           },
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<_i4.Employee?> getEmployeeBySpaceId({
+  _i8.Future<_i4.Employee?> getEmployeeBySpaceId({
     required String? userId,
     required String? spaceId,
   }) =>
@@ -412,54 +401,54 @@ class MockEmployeeService extends _i1.Mock implements _i12.EmployeeService {
             #spaceId: spaceId,
           },
         ),
-        returnValue: _i9.Future<_i4.Employee?>.value(),
-      ) as _i9.Future<_i4.Employee?>);
+        returnValue: _i8.Future<_i4.Employee?>.value(),
+      ) as _i8.Future<_i4.Employee?>);
   @override
-  _i9.Future<List<_i4.Employee>> getEmployees() => (super.noSuchMethod(
+  _i8.Future<List<_i4.Employee>> getEmployees() => (super.noSuchMethod(
         Invocation.method(
           #getEmployees,
           [],
         ),
-        returnValue: _i9.Future<List<_i4.Employee>>.value(<_i4.Employee>[]),
-      ) as _i9.Future<List<_i4.Employee>>);
+        returnValue: _i8.Future<List<_i4.Employee>>.value(<_i4.Employee>[]),
+      ) as _i8.Future<List<_i4.Employee>>);
   @override
-  _i9.Future<_i4.Employee?> getEmployee(String? id) => (super.noSuchMethod(
+  _i8.Future<_i4.Employee?> getEmployee(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getEmployee,
           [id],
         ),
-        returnValue: _i9.Future<_i4.Employee?>.value(),
-      ) as _i9.Future<_i4.Employee?>);
+        returnValue: _i8.Future<_i4.Employee?>.value(),
+      ) as _i8.Future<_i4.Employee?>);
   @override
-  _i9.Future<bool> hasUser(String? email) => (super.noSuchMethod(
+  _i8.Future<bool> hasUser(String? email) => (super.noSuchMethod(
         Invocation.method(
           #hasUser,
           [email],
         ),
-        returnValue: _i9.Future<bool>.value(false),
-      ) as _i9.Future<bool>);
+        returnValue: _i8.Future<bool>.value(false),
+      ) as _i8.Future<bool>);
   @override
-  _i9.Future<void> addEmployee(_i4.Employee? employee) => (super.noSuchMethod(
+  _i8.Future<void> addEmployee(_i4.Employee? employee) => (super.noSuchMethod(
         Invocation.method(
           #addEmployee,
           [employee],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<void> updateEmployeeDetails({required _i4.Employee? employee}) =>
+  _i8.Future<void> updateEmployeeDetails({required _i4.Employee? employee}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateEmployeeDetails,
           [],
           {#employee: employee},
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<void> changeEmployeeRoleType(
+  _i8.Future<void> changeEmployeeRoleType(
     String? id,
     _i4.Role? role,
   ) =>
@@ -471,24 +460,24 @@ class MockEmployeeService extends _i1.Mock implements _i12.EmployeeService {
             role,
           ],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<void> deleteEmployee(String? id) => (super.noSuchMethod(
+  _i8.Future<void> deleteEmployee(String? id) => (super.noSuchMethod(
         Invocation.method(
           #deleteEmployee,
           [id],
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
 }
 
 /// A class which mocks [AccountService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccountService extends _i1.Mock implements _i13.AccountService {
+class MockAccountService extends _i1.Mock implements _i12.AccountService {
   MockAccountService() {
     _i1.throwOnMissingStub(this);
   }
@@ -510,21 +499,21 @@ class MockAccountService extends _i1.Mock implements _i13.AccountService {
         ),
       ) as _i5.DeviceInfoProvider);
   @override
-  _i9.Future<_i6.Account> getUser(_i7.User? authData) => (super.noSuchMethod(
+  _i8.Future<_i6.Account> getUser(_i13.User? authData) => (super.noSuchMethod(
         Invocation.method(
           #getUser,
           [authData],
         ),
-        returnValue: _i9.Future<_i6.Account>.value(_FakeAccount_4(
+        returnValue: _i8.Future<_i6.Account>.value(_FakeAccount_4(
           this,
           Invocation.method(
             #getUser,
             [authData],
           ),
         )),
-      ) as _i9.Future<_i6.Account>);
+      ) as _i8.Future<_i6.Account>);
   @override
-  _i9.Future<void> updateSpaceOfUser({
+  _i8.Future<void> updateSpaceOfUser({
     required String? spaceID,
     required String? uid,
   }) =>
@@ -537,11 +526,11 @@ class MockAccountService extends _i1.Mock implements _i13.AccountService {
             #uid: uid,
           },
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<void> deleteSpaceIdFromAccount({
+  _i8.Future<void> deleteSpaceIdFromAccount({
     required String? spaceId,
     required String? uid,
   }) =>
@@ -554,59 +543,17 @@ class MockAccountService extends _i1.Mock implements _i13.AccountService {
             #uid: uid,
           },
         ),
-        returnValue: _i9.Future<void>.value(),
-        returnValueForMissingStub: _i9.Future<void>.value(),
-      ) as _i9.Future<void>);
+        returnValue: _i8.Future<void>.value(),
+        returnValueForMissingStub: _i8.Future<void>.value(),
+      ) as _i8.Future<void>);
   @override
-  _i9.Future<List<String>> fetchSpaceIds({required String? uid}) =>
+  _i8.Future<List<String>> fetchSpaceIds({required String? uid}) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchSpaceIds,
           [],
           {#uid: uid},
         ),
-        returnValue: _i9.Future<List<String>>.value(<String>[]),
-      ) as _i9.Future<List<String>>);
-}
-
-/// A class which mocks [AuthService].
-///
-/// See the documentation for Mockito's code generation for more information.
-class MockAuthService extends _i1.Mock implements _i14.AuthService {
-  MockAuthService() {
-    _i1.throwOnMissingStub(this);
-  }
-
-  @override
-  _i2.FirebaseFirestore get fireStore => (super.noSuchMethod(
-        Invocation.getter(#fireStore),
-        returnValue: _FakeFirebaseFirestore_0(
-          this,
-          Invocation.getter(#fireStore),
-        ),
-      ) as _i2.FirebaseFirestore);
-  @override
-  _i7.FirebaseAuth get firebaseAuth => (super.noSuchMethod(
-        Invocation.getter(#firebaseAuth),
-        returnValue: _FakeFirebaseAuth_5(
-          this,
-          Invocation.getter(#firebaseAuth),
-        ),
-      ) as _i7.FirebaseAuth);
-  @override
-  _i9.Future<_i7.User?> signInWithGoogle() => (super.noSuchMethod(
-        Invocation.method(
-          #signInWithGoogle,
-          [],
-        ),
-        returnValue: _i9.Future<_i7.User?>.value(),
-      ) as _i9.Future<_i7.User?>);
-  @override
-  _i9.Future<bool> signOutWithGoogle() => (super.noSuchMethod(
-        Invocation.method(
-          #signOutWithGoogle,
-          [],
-        ),
-        returnValue: _i9.Future<bool>.value(false),
-      ) as _i9.Future<bool>);
+        returnValue: _i8.Future<List<String>>.value(<String>[]),
+      ) as _i8.Future<List<String>>);
 }

--- a/test/unit_test/space/join_space/join_space_test.mocks.dart
+++ b/test/unit_test/space/join_space/join_space_test.mocks.dart
@@ -3,22 +3,23 @@
 // Do not manually edit this file.
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'dart:async' as _i8;
-import 'dart:ui' as _i12;
+import 'dart:async' as _i9;
+import 'dart:ui' as _i13;
 
 import 'package:cloud_firestore/cloud_firestore.dart' as _i2;
-import 'package:firebase_auth/firebase_auth.dart' as _i14;
+import 'package:firebase_auth/firebase_auth.dart' as _i7;
 import 'package:mockito/mockito.dart' as _i1;
 import 'package:projectunity/data/model/account/account.dart' as _i6;
 import 'package:projectunity/data/model/employee/employee.dart' as _i4;
-import 'package:projectunity/data/model/invitation/invitation.dart' as _i9;
+import 'package:projectunity/data/model/invitation/invitation.dart' as _i10;
 import 'package:projectunity/data/model/space/space.dart' as _i3;
 import 'package:projectunity/data/provider/device_info.dart' as _i5;
-import 'package:projectunity/data/provider/user_state.dart' as _i11;
-import 'package:projectunity/data/services/account_service.dart' as _i13;
+import 'package:projectunity/data/provider/user_state.dart' as _i12;
+import 'package:projectunity/data/services/account_service.dart' as _i14;
+import 'package:projectunity/data/services/auth_service.dart' as _i16;
 import 'package:projectunity/data/services/employee_service.dart' as _i15;
-import 'package:projectunity/data/services/invitation_services.dart' as _i7;
-import 'package:projectunity/data/services/space_service.dart' as _i10;
+import 'package:projectunity/data/services/invitation_services.dart' as _i8;
+import 'package:projectunity/data/services/space_service.dart' as _i11;
 
 // ignore_for_file: type=lint
 // ignore_for_file: avoid_redundant_argument_values
@@ -83,10 +84,20 @@ class _FakeAccount_4 extends _i1.SmartFake implements _i6.Account {
         );
 }
 
+class _FakeFirebaseAuth_5 extends _i1.SmartFake implements _i7.FirebaseAuth {
+  _FakeFirebaseAuth_5(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
 /// A class which mocks [InvitationService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockInvitationService extends _i1.Mock implements _i7.InvitationService {
+class MockInvitationService extends _i1.Mock implements _i8.InvitationService {
   MockInvitationService() {
     _i1.throwOnMissingStub(this);
   }
@@ -100,16 +111,17 @@ class MockInvitationService extends _i1.Mock implements _i7.InvitationService {
         ),
       ) as _i2.FirebaseFirestore);
   @override
-  _i8.Future<List<_i9.Invitation>> fetchSpacesForUserEmail(String? email) =>
+  _i9.Future<List<_i10.Invitation>> fetchSpacesForUserEmail(String? email) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchSpacesForUserEmail,
           [email],
         ),
-        returnValue: _i8.Future<List<_i9.Invitation>>.value(<_i9.Invitation>[]),
-      ) as _i8.Future<List<_i9.Invitation>>);
+        returnValue:
+            _i9.Future<List<_i10.Invitation>>.value(<_i10.Invitation>[]),
+      ) as _i9.Future<List<_i10.Invitation>>);
   @override
-  _i8.Future<bool> checkMemberInvitationAlreadyExist({
+  _i9.Future<bool> checkMemberInvitationAlreadyExist({
     required String? spaceId,
     required String? email,
   }) =>
@@ -122,10 +134,10 @@ class MockInvitationService extends _i1.Mock implements _i7.InvitationService {
             #email: email,
           },
         ),
-        returnValue: _i8.Future<bool>.value(false),
-      ) as _i8.Future<bool>);
+        returnValue: _i9.Future<bool>.value(false),
+      ) as _i9.Future<bool>);
   @override
-  _i8.Future<List<_i9.Invitation>> fetchSpaceInvitations(
+  _i9.Future<List<_i10.Invitation>> fetchSpaceInvitations(
           {required String? spaceId}) =>
       (super.noSuchMethod(
         Invocation.method(
@@ -133,10 +145,11 @@ class MockInvitationService extends _i1.Mock implements _i7.InvitationService {
           [],
           {#spaceId: spaceId},
         ),
-        returnValue: _i8.Future<List<_i9.Invitation>>.value(<_i9.Invitation>[]),
-      ) as _i8.Future<List<_i9.Invitation>>);
+        returnValue:
+            _i9.Future<List<_i10.Invitation>>.value(<_i10.Invitation>[]),
+      ) as _i9.Future<List<_i10.Invitation>>);
   @override
-  _i8.Future<void> addInvitation({
+  _i9.Future<void> addInvitation({
     required String? senderId,
     required String? spaceId,
     required String? receiverEmail,
@@ -151,26 +164,26 @@ class MockInvitationService extends _i1.Mock implements _i7.InvitationService {
             #receiverEmail: receiverEmail,
           },
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> deleteInvitation({required String? id}) =>
+  _i9.Future<void> deleteInvitation({required String? id}) =>
       (super.noSuchMethod(
         Invocation.method(
           #deleteInvitation,
           [],
           {#id: id},
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
 }
 
 /// A class which mocks [SpaceService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockSpaceService extends _i1.Mock implements _i10.SpaceService {
+class MockSpaceService extends _i1.Mock implements _i11.SpaceService {
   MockSpaceService() {
     _i1.throwOnMissingStub(this);
   }
@@ -192,15 +205,15 @@ class MockSpaceService extends _i1.Mock implements _i10.SpaceService {
         returnValueForMissingStub: null,
       );
   @override
-  _i8.Future<_i3.Space?> getSpace(String? spaceId) => (super.noSuchMethod(
+  _i9.Future<_i3.Space?> getSpace(String? spaceId) => (super.noSuchMethod(
         Invocation.method(
           #getSpace,
           [spaceId],
         ),
-        returnValue: _i8.Future<_i3.Space?>.value(),
-      ) as _i8.Future<_i3.Space?>);
+        returnValue: _i9.Future<_i3.Space?>.value(),
+      ) as _i9.Future<_i3.Space?>);
   @override
-  _i8.Future<_i3.Space> createSpace({
+  _i9.Future<_i3.Space> createSpace({
     String? logo,
     required String? name,
     String? domain,
@@ -219,7 +232,7 @@ class MockSpaceService extends _i1.Mock implements _i10.SpaceService {
             #ownerId: ownerId,
           },
         ),
-        returnValue: _i8.Future<_i3.Space>.value(_FakeSpace_1(
+        returnValue: _i9.Future<_i3.Space>.value(_FakeSpace_1(
           this,
           Invocation.method(
             #createSpace,
@@ -233,18 +246,18 @@ class MockSpaceService extends _i1.Mock implements _i10.SpaceService {
             },
           ),
         )),
-      ) as _i8.Future<_i3.Space>);
+      ) as _i9.Future<_i3.Space>);
   @override
-  _i8.Future<void> updateSpace(_i3.Space? space) => (super.noSuchMethod(
+  _i9.Future<void> updateSpace(_i3.Space? space) => (super.noSuchMethod(
         Invocation.method(
           #updateSpace,
           [space],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> deleteSpace(
+  _i9.Future<void> deleteSpace(
     String? workspaceId,
     List<String>? owners,
   ) =>
@@ -256,30 +269,30 @@ class MockSpaceService extends _i1.Mock implements _i10.SpaceService {
             owners,
           ],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<List<_i3.Space>> getSpacesOfUser(String? uid) =>
+  _i9.Future<List<_i3.Space>> getSpacesOfUser(String? uid) =>
       (super.noSuchMethod(
         Invocation.method(
           #getSpacesOfUser,
           [uid],
         ),
-        returnValue: _i8.Future<List<_i3.Space>>.value(<_i3.Space>[]),
-      ) as _i8.Future<List<_i3.Space>>);
+        returnValue: _i9.Future<List<_i3.Space>>.value(<_i3.Space>[]),
+      ) as _i9.Future<List<_i3.Space>>);
   @override
-  _i8.Future<int> getPaidLeaves({required String? spaceId}) =>
+  _i9.Future<int> getPaidLeaves({required String? spaceId}) =>
       (super.noSuchMethod(
         Invocation.method(
           #getPaidLeaves,
           [],
           {#spaceId: spaceId},
         ),
-        returnValue: _i8.Future<int>.value(0),
-      ) as _i8.Future<int>);
+        returnValue: _i9.Future<int>.value(0),
+      ) as _i9.Future<int>);
   @override
-  _i8.Future<void> updateLeaveCount({
+  _i9.Future<void> updateLeaveCount({
     required String? spaceId,
     required int? paidLeaveCount,
   }) =>
@@ -292,24 +305,24 @@ class MockSpaceService extends _i1.Mock implements _i10.SpaceService {
             #paidLeaveCount: paidLeaveCount,
           },
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
 }
 
 /// A class which mocks [UserStateNotifier].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockUserStateNotifier extends _i1.Mock implements _i11.UserStateNotifier {
+class MockUserStateNotifier extends _i1.Mock implements _i12.UserStateNotifier {
   MockUserStateNotifier() {
     _i1.throwOnMissingStub(this);
   }
 
   @override
-  _i11.UserState get state => (super.noSuchMethod(
+  _i12.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i11.UserState.unknown,
-      ) as _i11.UserState);
+        returnValue: _i12.UserState.unknown,
+      ) as _i12.UserState);
   @override
   String get employeeId => (super.noSuchMethod(
         Invocation.getter(#employeeId),
@@ -352,16 +365,16 @@ class MockUserStateNotifier extends _i1.Mock implements _i11.UserStateNotifier {
         returnValueForMissingStub: null,
       );
   @override
-  _i8.Future<void> setUser(_i6.Account? user) => (super.noSuchMethod(
+  _i9.Future<void> setUser(_i6.Account? user) => (super.noSuchMethod(
         Invocation.method(
           #setUser,
           [user],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> setEmployeeWithSpace({
+  _i9.Future<void> setEmployeeWithSpace({
     required _i3.Space? space,
     required _i4.Employee? spaceUser,
     bool? redirect = true,
@@ -376,38 +389,38 @@ class MockUserStateNotifier extends _i1.Mock implements _i11.UserStateNotifier {
             #redirect: redirect,
           },
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> updateSpace(_i3.Space? space) => (super.noSuchMethod(
+  _i9.Future<void> updateSpace(_i3.Space? space) => (super.noSuchMethod(
         Invocation.method(
           #updateSpace,
           [space],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> removeEmployeeWithSpace() => (super.noSuchMethod(
+  _i9.Future<void> removeEmployeeWithSpace() => (super.noSuchMethod(
         Invocation.method(
           #removeEmployeeWithSpace,
           [],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> removeAll() => (super.noSuchMethod(
+  _i9.Future<void> removeAll() => (super.noSuchMethod(
         Invocation.method(
           #removeAll,
           [],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  void addListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void addListener(_i13.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #addListener,
           [listener],
@@ -415,7 +428,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i11.UserStateNotifier {
         returnValueForMissingStub: null,
       );
   @override
-  void removeListener(_i12.VoidCallback? listener) => super.noSuchMethod(
+  void removeListener(_i13.VoidCallback? listener) => super.noSuchMethod(
         Invocation.method(
           #removeListener,
           [listener],
@@ -443,7 +456,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i11.UserStateNotifier {
 /// A class which mocks [AccountService].
 ///
 /// See the documentation for Mockito's code generation for more information.
-class MockAccountService extends _i1.Mock implements _i13.AccountService {
+class MockAccountService extends _i1.Mock implements _i14.AccountService {
   MockAccountService() {
     _i1.throwOnMissingStub(this);
   }
@@ -465,21 +478,21 @@ class MockAccountService extends _i1.Mock implements _i13.AccountService {
         ),
       ) as _i5.DeviceInfoProvider);
   @override
-  _i8.Future<_i6.Account> getUser(_i14.User? authData) => (super.noSuchMethod(
+  _i9.Future<_i6.Account> getUser(_i7.User? authData) => (super.noSuchMethod(
         Invocation.method(
           #getUser,
           [authData],
         ),
-        returnValue: _i8.Future<_i6.Account>.value(_FakeAccount_4(
+        returnValue: _i9.Future<_i6.Account>.value(_FakeAccount_4(
           this,
           Invocation.method(
             #getUser,
             [authData],
           ),
         )),
-      ) as _i8.Future<_i6.Account>);
+      ) as _i9.Future<_i6.Account>);
   @override
-  _i8.Future<void> updateSpaceOfUser({
+  _i9.Future<void> updateSpaceOfUser({
     required String? spaceID,
     required String? uid,
   }) =>
@@ -492,11 +505,11 @@ class MockAccountService extends _i1.Mock implements _i13.AccountService {
             #uid: uid,
           },
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> deleteSpaceIdFromAccount({
+  _i9.Future<void> deleteSpaceIdFromAccount({
     required String? spaceId,
     required String? uid,
   }) =>
@@ -509,19 +522,19 @@ class MockAccountService extends _i1.Mock implements _i13.AccountService {
             #uid: uid,
           },
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<List<String>> fetchSpaceIds({required String? uid}) =>
+  _i9.Future<List<String>> fetchSpaceIds({required String? uid}) =>
       (super.noSuchMethod(
         Invocation.method(
           #fetchSpaceIds,
           [],
           {#uid: uid},
         ),
-        returnValue: _i8.Future<List<String>>.value(<String>[]),
-      ) as _i8.Future<List<String>>);
+        returnValue: _i9.Future<List<String>>.value(<String>[]),
+      ) as _i9.Future<List<String>>);
 }
 
 /// A class which mocks [EmployeeService].
@@ -541,7 +554,7 @@ class MockEmployeeService extends _i1.Mock implements _i15.EmployeeService {
         ),
       ) as _i2.FirebaseFirestore);
   @override
-  _i8.Future<void> addEmployeeBySpaceId({
+  _i9.Future<void> addEmployeeBySpaceId({
     required _i4.Employee? employee,
     required String? spaceId,
   }) =>
@@ -554,11 +567,11 @@ class MockEmployeeService extends _i1.Mock implements _i15.EmployeeService {
             #spaceId: spaceId,
           },
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<_i4.Employee?> getEmployeeBySpaceId({
+  _i9.Future<_i4.Employee?> getEmployeeBySpaceId({
     required String? userId,
     required String? spaceId,
   }) =>
@@ -571,54 +584,54 @@ class MockEmployeeService extends _i1.Mock implements _i15.EmployeeService {
             #spaceId: spaceId,
           },
         ),
-        returnValue: _i8.Future<_i4.Employee?>.value(),
-      ) as _i8.Future<_i4.Employee?>);
+        returnValue: _i9.Future<_i4.Employee?>.value(),
+      ) as _i9.Future<_i4.Employee?>);
   @override
-  _i8.Future<List<_i4.Employee>> getEmployees() => (super.noSuchMethod(
+  _i9.Future<List<_i4.Employee>> getEmployees() => (super.noSuchMethod(
         Invocation.method(
           #getEmployees,
           [],
         ),
-        returnValue: _i8.Future<List<_i4.Employee>>.value(<_i4.Employee>[]),
-      ) as _i8.Future<List<_i4.Employee>>);
+        returnValue: _i9.Future<List<_i4.Employee>>.value(<_i4.Employee>[]),
+      ) as _i9.Future<List<_i4.Employee>>);
   @override
-  _i8.Future<_i4.Employee?> getEmployee(String? id) => (super.noSuchMethod(
+  _i9.Future<_i4.Employee?> getEmployee(String? id) => (super.noSuchMethod(
         Invocation.method(
           #getEmployee,
           [id],
         ),
-        returnValue: _i8.Future<_i4.Employee?>.value(),
-      ) as _i8.Future<_i4.Employee?>);
+        returnValue: _i9.Future<_i4.Employee?>.value(),
+      ) as _i9.Future<_i4.Employee?>);
   @override
-  _i8.Future<bool> hasUser(String? email) => (super.noSuchMethod(
+  _i9.Future<bool> hasUser(String? email) => (super.noSuchMethod(
         Invocation.method(
           #hasUser,
           [email],
         ),
-        returnValue: _i8.Future<bool>.value(false),
-      ) as _i8.Future<bool>);
+        returnValue: _i9.Future<bool>.value(false),
+      ) as _i9.Future<bool>);
   @override
-  _i8.Future<void> addEmployee(_i4.Employee? employee) => (super.noSuchMethod(
+  _i9.Future<void> addEmployee(_i4.Employee? employee) => (super.noSuchMethod(
         Invocation.method(
           #addEmployee,
           [employee],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> updateEmployeeDetails({required _i4.Employee? employee}) =>
+  _i9.Future<void> updateEmployeeDetails({required _i4.Employee? employee}) =>
       (super.noSuchMethod(
         Invocation.method(
           #updateEmployeeDetails,
           [],
           {#employee: employee},
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> changeEmployeeRoleType(
+  _i9.Future<void> changeEmployeeRoleType(
     String? id,
     _i4.Role? role,
   ) =>
@@ -630,16 +643,58 @@ class MockEmployeeService extends _i1.Mock implements _i15.EmployeeService {
             role,
           ],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
   @override
-  _i8.Future<void> deleteEmployee(String? id) => (super.noSuchMethod(
+  _i9.Future<void> deleteEmployee(String? id) => (super.noSuchMethod(
         Invocation.method(
           #deleteEmployee,
           [id],
         ),
-        returnValue: _i8.Future<void>.value(),
-        returnValueForMissingStub: _i8.Future<void>.value(),
-      ) as _i8.Future<void>);
+        returnValue: _i9.Future<void>.value(),
+        returnValueForMissingStub: _i9.Future<void>.value(),
+      ) as _i9.Future<void>);
+}
+
+/// A class which mocks [AuthService].
+///
+/// See the documentation for Mockito's code generation for more information.
+class MockAuthService extends _i1.Mock implements _i16.AuthService {
+  MockAuthService() {
+    _i1.throwOnMissingStub(this);
+  }
+
+  @override
+  _i2.FirebaseFirestore get fireStore => (super.noSuchMethod(
+        Invocation.getter(#fireStore),
+        returnValue: _FakeFirebaseFirestore_0(
+          this,
+          Invocation.getter(#fireStore),
+        ),
+      ) as _i2.FirebaseFirestore);
+  @override
+  _i7.FirebaseAuth get firebaseAuth => (super.noSuchMethod(
+        Invocation.getter(#firebaseAuth),
+        returnValue: _FakeFirebaseAuth_5(
+          this,
+          Invocation.getter(#firebaseAuth),
+        ),
+      ) as _i7.FirebaseAuth);
+  @override
+  _i9.Future<_i7.User?> signInWithGoogle() => (super.noSuchMethod(
+        Invocation.method(
+          #signInWithGoogle,
+          [],
+        ),
+        returnValue: _i9.Future<_i7.User?>.value(),
+      ) as _i9.Future<_i7.User?>);
+  @override
+  _i9.Future<bool> signOutWithGoogle() => (super.noSuchMethod(
+        Invocation.method(
+          #signOutWithGoogle,
+          [],
+        ),
+        returnValue: _i9.Future<bool>.value(false),
+      ) as _i9.Future<bool>);
 }


### PR DESCRIPTION
### Purpose
 - Fix leave type not shown 
 - User sould be able to sign out with space and navigate join space.

### Summary of Changes
 - Fix some ui issues 
 - Add sign out with space button
 - Add sign out in join space for sign out with current account
 - Update test according new change

### Test steps
 - Run flutter test

### Conformity
- [x] Followed [git guidelines](https://github.com/canopas/flutter-developer-roadmap/blob/main/GitGuideline.md) for creating commit messages and Pull Request guidelines.
- [x] Self-approved the PR - reviewed the PR as a reviewer and gave it self-approval if everything is ok. If not, made the required changes.
- [x] Ensured that the PR satisfies all specified requirements in the ticket, including bug fixes and new features.
- [x] Provided test steps, including steps to reproduce the issue or test the new functionality, ensuring other team members can verify the changes.
- [x] Added/Updated proper code comments to make it easy-to-understand for other developers.
- [x] Reused code (if the same code was written twice, made it common and reused it at both places).
- [x] Removed unused or commented code if not required.
- [x] Ensured proper Dart naming conventions were used for variables, classes, and methods.
- [x] Localized user-facing strings.
- [x] Included screenshots/videos of behavior changes: Provided visual evidence of any changes to UI or behavior for easier review and understanding in the PR description.
- [x] Implemented proper error handling: Ensured that the code anticipated and handled potential errors and edge cases gracefully.
- [x] Avoided introducing technical debt: If the PR introduces technical debt, created and linked appropriate tickets for future resolution.
- [x] Included relevant unit tests: Wrote unit tests that focused on testing behavior and functionality, rather than merely covering lines of code.
- [x] Ensured code was performant and scalable: Verified that the changes did not introduce performance issues or bottlenecks and could scale as needed.
- [x] Ensured comments were up-to-date and relevant to the code to describe complex logic and to add understanding for other developers.
- [x] Marked the PR as ready before submitting it for review.

### Visual Evidence (Video, Images or Gif)
<img src="https://github.com/canopas/canopas-unity/assets/109139581/5a5448e6-3a1a-4b7e-ad78-323c166387bf" width="303" height="656"/>
<img src="https://github.com/canopas/canopas-unity/assets/109139581/b88bf3bf-8097-4f95-9696-3cb18f711969" width="303" height="656"/>
