### PR TITLE
Show only used leave count if paid leave count is 0

### DIFF
--- a/lib/data/di/service_locator.config.dart
+++ b/lib/data/di/service_locator.config.dart
@@ -237,8 +237,6 @@ extension GetItInjectableX on _i1.GetIt {
         ));
     gh.factory<_i45.AdminLeaveDetailsBloc>(() => _i45.AdminLeaveDetailsBloc(
           gh<_i30.LeaveService>(),
-          gh<_i22.UserStateNotifier>(),
-          gh<_i19.SpaceService>(),
           gh<_i16.NotificationService>(),
         ));
     gh.factory<_i46.AdminLeavesBloc>(() => _i46.AdminLeavesBloc(

--- a/lib/ui/admin/leaves/details/bloc/admin_leave_details_bloc.dart
+++ b/lib/ui/admin/leaves/details/bloc/admin_leave_details_bloc.dart
@@ -1,8 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:projectunity/data/core/utils/bloc_status.dart';
-import 'package:projectunity/data/provider/user_state.dart';
-import 'package:projectunity/data/services/space_service.dart';
 import '../../../../../data/core/exception/error_const.dart';
 import '../../../../../data/services/leave_service.dart';
 import '../../../../../data/services/mail_notification_service.dart';
@@ -12,15 +10,11 @@ import 'admin_leave_details_state.dart';
 @Injectable()
 class AdminLeaveDetailsBloc
     extends Bloc<AdminLeaveDetailsEvents, AdminLeaveDetailsState> {
-  final UserStateNotifier _userManager;
-  final SpaceService _spaceService;
   final LeaveService _leaveService;
   final NotificationService _notificationService;
 
   AdminLeaveDetailsBloc(
     this._leaveService,
-    this._userManager,
-    this._spaceService,
     this._notificationService,
   ) : super(const AdminLeaveDetailsState()) {
     on<AdminLeaveDetailsFetchLeaveCountEvent>(_fetchLeaveCounts);
@@ -32,14 +26,10 @@ class AdminLeaveDetailsBloc
       Emitter<AdminLeaveDetailsState> emit) async {
     emit(state.copyWith(leaveCountStatus: Status.loading));
     try {
-      int paidLeaves = await _spaceService.getPaidLeaves(
-          spaceId: _userManager.currentSpaceId!);
       double usedLeave =
           await _leaveService.getUserUsedLeaves(event.employeeId);
       emit(state.copyWith(
-          leaveCountStatus: Status.success,
-          paidLeaveCount: paidLeaves,
-          usedLeaves: usedLeave));
+          leaveCountStatus: Status.success, usedLeaves: usedLeave));
     } on Exception {
       emit(state.copyWith(
           error: firestoreFetchDataError, leaveCountStatus: Status.error));

--- a/lib/ui/admin/leaves/details/bloc/admin_leave_details_state.dart
+++ b/lib/ui/admin/leaves/details/bloc/admin_leave_details_state.dart
@@ -4,14 +4,12 @@ import '../../../../../data/core/utils/bloc_status.dart';
 class AdminLeaveDetailsState extends Equatable {
   final Status actionStatus;
   final Status leaveCountStatus;
-  final int paidLeaveCount;
   final double usedLeaves;
   final String? error;
   final String adminReply;
 
   const AdminLeaveDetailsState({
     this.adminReply = "",
-    this.paidLeaveCount = 0,
     this.usedLeaves = 0.0,
     this.error,
     this.actionStatus = Status.initial,
@@ -19,8 +17,7 @@ class AdminLeaveDetailsState extends Equatable {
   });
 
   AdminLeaveDetailsState copyWith(
-      {int? paidLeaveCount,
-      double? usedLeaves,
+      {double? usedLeaves,
       String? error,
       Status? actionStatus,
       Status? leaveCountStatus,
@@ -28,21 +25,13 @@ class AdminLeaveDetailsState extends Equatable {
     return AdminLeaveDetailsState(
       adminReply: adminReply ?? this.adminReply,
       error: error,
-      paidLeaveCount: paidLeaveCount ?? this.paidLeaveCount,
       usedLeaves: usedLeaves ?? this.usedLeaves,
       actionStatus: actionStatus ?? this.actionStatus,
-      leaveCountStatus:
-          leaveCountStatus ?? this.leaveCountStatus,
+      leaveCountStatus: leaveCountStatus ?? this.leaveCountStatus,
     );
   }
 
   @override
-  List<Object?> get props => [
-        error,
-        leaveCountStatus,
-        actionStatus,
-        paidLeaveCount,
-        usedLeaves,
-        adminReply
-      ];
+  List<Object?> get props =>
+      [error, leaveCountStatus, actionStatus, usedLeaves, adminReply];
 }

--- a/lib/ui/admin/leaves/details/widget/admin_leave_details_date_content.dart
+++ b/lib/ui/admin/leaves/details/widget/admin_leave_details_date_content.dart
@@ -44,19 +44,30 @@ class AdminLeaveRequestDetailsDateContent extends StatelessWidget {
             buildWhen: (previous, current) => previous.leaveCountStatus != current.leaveCountStatus,
             builder: (context, state) => state.leaveCountStatus == Status.loading
                 ? const AppCircularProgressIndicator(size: 28)
-                : Text("${state.usedLeaves.fixedAt(2)}/${state.paidLeaveCount}",
-                    style: AppFontStyle.titleDark),
+                : Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text( state.paidLeaveCount==0?state.usedLeaves.fixedAt(2).toString():"${state.usedLeaves.fixedAt(2)}/${state.paidLeaveCount}",
+                        style: AppFontStyle.titleDark),
+                    const SizedBox(height: 8),
+                    Text(
+                      AppLocalizations.of(context).user_leave_used_leaves_tag,
+                      style: AppFontStyle.bodyMedium
+                          .copyWith(color: AppColors.primaryBlue),
+                    )
+                  ],
+                ),
           ),
           Expanded(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.end,
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
-                Text(duration, style: AppFontStyle.labelRegular),
-                SizedBox(height: MediaQuery.of(context).size.height * 0.01),
+                Text(duration, style: AppFontStyle.titleDark),
+                const SizedBox(height:8),
                 Text(
                   totalDays,
-                  style: AppFontStyle.bodySmallHeavy
+                  style: AppFontStyle.bodyMedium
                       .copyWith(color: AppColors.primaryBlue),
                 ),
               ],

--- a/lib/ui/admin/leaves/details/widget/admin_leave_details_date_content.dart
+++ b/lib/ui/admin/leaves/details/widget/admin_leave_details_date_content.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_gen/gen_l10n/app_localization.dart';
 import 'package:projectunity/data/core/extensions/double_extension.dart';
-
 import '../../../../../data/configs/colors.dart';
 import '../../../../../data/configs/space_constant.dart';
 import '../../../../../data/configs/text_style.dart';
@@ -47,7 +46,7 @@ class AdminLeaveRequestDetailsDateContent extends StatelessWidget {
                 : Column(
               crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Text( state.paidLeaveCount==0?state.usedLeaves.fixedAt(2).toString():"${state.usedLeaves.fixedAt(2)}/${state.paidLeaveCount}",
+                    Text(state.usedLeaves.fixedAt(2).toString(),
                         style: AppFontStyle.titleDark),
                     const SizedBox(height: 8),
                     Text(

--- a/lib/ui/admin/members/detail/bloc/employee_detail_bloc.dart
+++ b/lib/ui/admin/members/detail/bloc/employee_detail_bloc.dart
@@ -49,7 +49,6 @@ class EmployeeDetailBloc
         emit(EmployeeDetailLoadedState(
             employee: employee,
             timeOffRatio: percentage,
-            paidLeaves: totalLeaves,
             usedLeaves: usedLeaves));
       } else {
         emit(EmployeeDetailFailureState(error: firestoreFetchDataError));

--- a/lib/ui/admin/members/detail/bloc/employee_detail_state.dart
+++ b/lib/ui/admin/members/detail/bloc/employee_detail_state.dart
@@ -13,17 +13,15 @@ class EmployeeDetailLoadingState extends AdminEmployeeDetailState {}
 class EmployeeDetailLoadedState extends AdminEmployeeDetailState {
   final Employee employee;
   final double timeOffRatio;
-  final int paidLeaves;
   final double usedLeaves;
 
   EmployeeDetailLoadedState(
       {required this.employee,
       required this.timeOffRatio,
-      required this.paidLeaves,
       required this.usedLeaves});
 
   @override
-  List<Object?> get props => [employee, timeOffRatio, paidLeaves, usedLeaves];
+  List<Object?> get props => [employee, timeOffRatio, usedLeaves];
 }
 
 class EmployeeDetailFailureState extends AdminEmployeeDetailState {

--- a/lib/ui/admin/members/detail/employee_detail_screen.dart
+++ b/lib/ui/admin/members/detail/employee_detail_screen.dart
@@ -119,7 +119,6 @@ class _EmployeeDetailScreenState extends State<EmployeeDetailScreen> {
                       employee: state.employee,
                       percentage: state.timeOffRatio,
                       usedLeaves: state.usedLeaves,
-                      paidLeaves: state.paidLeaves,
                     ),
                   ),
                   ProfileDetail(employee: state.employee),

--- a/lib/ui/admin/members/detail/widget/profile_detail.dart
+++ b/lib/ui/admin/members/detail/widget/profile_detail.dart
@@ -57,13 +57,11 @@ class TimeOffCard extends StatelessWidget {
     Key? key,
     required this.percentage,
     required this.usedLeaves,
-    required this.paidLeaves,
     required this.employee,
   }) : super(key: key);
   final Employee employee;
   final double percentage;
   final double usedLeaves;
-  final int paidLeaves;
 
   @override
   Widget build(BuildContext context) {
@@ -112,7 +110,7 @@ class TimeOffCard extends StatelessWidget {
                 Row(
                   children: [
                     Text(
-                      paidLeaves == 0?usedLeaves.fixedAt(2).toString():'$usedLeaves/$paidLeaves',
+                      usedLeaves.fixedAt(2).toString(),
                       style: AppFontStyle.titleRegular,
                     ),
                     const SizedBox(width: 10),

--- a/lib/ui/admin/members/detail/widget/profile_detail.dart
+++ b/lib/ui/admin/members/detail/widget/profile_detail.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_gen/gen_l10n/app_localization.dart';
 import 'package:go_router/go_router.dart';
 import 'package:projectunity/data/configs/theme.dart';
+import 'package:projectunity/data/core/extensions/double_extension.dart';
 import '../../../../../data/configs/colors.dart';
 import '../../../../../data/configs/space_constant.dart';
 import '../../../../../data/configs/text_style.dart';
@@ -111,10 +112,10 @@ class TimeOffCard extends StatelessWidget {
                 Row(
                   children: [
                     Text(
-                      '$usedLeaves/$paidLeaves',
+                      paidLeaves == 0?usedLeaves.fixedAt(2).toString():'$usedLeaves/$paidLeaves',
                       style: AppFontStyle.titleRegular,
                     ),
-                    const SizedBox(width: 20),
+                    const SizedBox(width: 10),
                     const Icon(
                       Icons.arrow_forward_ios_outlined,
                       color: AppColors.greyColor,

--- a/lib/ui/user/leaves/leaves_screen/bloc/leave_count/user_leave_count_bloc.dart
+++ b/lib/ui/user/leaves/leaves_screen/bloc/leave_count/user_leave_count_bloc.dart
@@ -35,7 +35,6 @@ class UserLeaveCountBloc
       emit(state.copyWith(
           status: Status.success,
           used: usedLeaves,
-          totalLeaves: totalLeaves,
           leavePercentage: percentage));
     } on Exception {
       emit(state.copyWith(

--- a/lib/ui/user/leaves/leaves_screen/bloc/leave_count/user_leave_count_state.dart
+++ b/lib/ui/user/leaves/leaves_screen/bloc/leave_count/user_leave_count_state.dart
@@ -3,7 +3,6 @@ import '../../../../../../data/core/utils/bloc_status.dart';
 
 class UserLeaveCountState extends Equatable {
   final Status status;
-  final int totalLeaves;
   final double used;
   final double leavePercentage;
   final String? error;
@@ -11,25 +10,22 @@ class UserLeaveCountState extends Equatable {
   const UserLeaveCountState(
       {this.status = Status.initial,
       this.used = 0,
-      this.totalLeaves = 0,
       this.leavePercentage = 0,
       this.error});
 
   UserLeaveCountState copyWith(
       {Status? status,
       double? used,
-      int? totalLeaves,
       String? error,
       double? leavePercentage}) {
     return UserLeaveCountState(
         status: status ?? this.status,
         used: used ?? this.used,
-        totalLeaves: totalLeaves ?? this.totalLeaves,
         leavePercentage: leavePercentage ?? this.leavePercentage,
         error: error ?? this.error);
   }
 
   @override
   List<Object?> get props =>
-      [status, used, leavePercentage, totalLeaves, error];
+      [status, used, leavePercentage, error];
 }

--- a/lib/ui/user/leaves/leaves_screen/widget/leave_count_card.dart
+++ b/lib/ui/user/leaves/leaves_screen/widget/leave_count_card.dart
@@ -27,44 +27,46 @@ class LeaveCountCard extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20.0),
         child: BlocConsumer<UserLeaveCountBloc, UserLeaveCountState>(
-          listenWhen: (previous, current) => current.status == Status.error,
-           listener: (context, state) {
-             if(state.status == Status.error) {
-               showSnackBar(context: context, error: state.error);
-             }
-           },
+            listenWhen: (previous, current) => current.status == Status.error,
+            listener: (context, state) {
+              if (state.status == Status.error) {
+                showSnackBar(context: context, error: state.error);
+              }
+            },
             builder: (context, state) {
-          return Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              SizedBox(
-                height: 50,
-                width: 50,
-                child: CircularProgressIndicator(
-                  strokeWidth: 8,
-                  color: AppColors.primaryBlue,
-                  backgroundColor: AppColors.lightPrimaryBlue,
-                  value: state.leavePercentage,
-                ),
-              ),
-              Column(
-                crossAxisAlignment: CrossAxisAlignment.end,
-                mainAxisAlignment: MainAxisAlignment.center,
+              return Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 children: [
-                  Text(
-                    '${state.used}/${state.totalLeaves}',
-                    style: AppFontStyle.headerGrey
-                        .copyWith(color: AppColors.primaryBlue),
+                  SizedBox(
+                    height: 50,
+                    width: 50,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 8,
+                      color: AppColors.primaryBlue,
+                      backgroundColor: AppColors.lightPrimaryBlue,
+                      value: state.leavePercentage,
+                    ),
                   ),
-                  Text(
-                    AppLocalizations.of(context).user_leave_used_leaves_tag,
-                    style: AppFontStyle.labelRegular,
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text(
+                        state.totalLeaves == 0
+                            ? state.used.toString()
+                            : "${state.used}/${state.totalLeaves}",
+                        style: AppFontStyle.headerGrey
+                            .copyWith(color: AppColors.primaryBlue),
+                      ),
+                      Text(
+                        AppLocalizations.of(context).user_leave_used_leaves_tag,
+                        style: AppFontStyle.labelRegular,
+                      )
+                    ],
                   )
                 ],
-              )
-            ],
-          );
-        }),
+              );
+            }),
       ),
     );
   }

--- a/lib/ui/user/leaves/leaves_screen/widget/leave_count_card.dart
+++ b/lib/ui/user/leaves/leaves_screen/widget/leave_count_card.dart
@@ -52,9 +52,7 @@ class LeaveCountCard extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.center,
                     children: [
                       Text(
-                        state.totalLeaves == 0
-                            ? state.used.toString()
-                            : "${state.used}/${state.totalLeaves}",
+                        state.used.toString(),
                         style: AppFontStyle.headerGrey
                             .copyWith(color: AppColors.primaryBlue),
                       ),

--- a/test/unit_test/admin/leaves/application_detail/admin_leave_request_details_bloc_test.dart
+++ b/test/unit_test/admin/leaves/application_detail/admin_leave_request_details_bloc_test.dart
@@ -20,17 +20,13 @@ import 'admin_leave_request_details_bloc_test.mocks.dart';
 void main() {
   late LeaveService leaveService;
   late AdminLeaveDetailsBloc bloc;
-  late UserStateNotifier userStateNotifier;
-  late SpaceService spaceService;
   late NotificationService notificationService;
 
   setUp(() {
     leaveService = MockLeaveService();
-    userStateNotifier = MockUserStateNotifier();
-    spaceService = MockSpaceService();
     notificationService = MockNotificationService();
     bloc = AdminLeaveDetailsBloc(
-        leaveService, userStateNotifier, spaceService, notificationService);
+        leaveService, notificationService);
   });
 
   group('Leave Application Detail bloc', () {
@@ -38,7 +34,6 @@ void main() {
       AdminLeaveDetailsState leaveCountLoadingState =
           const AdminLeaveDetailsState(
               adminReply: '',
-              paidLeaveCount: 0,
               usedLeaves: 0.0,
               error: null,
               leaveCountStatus: Status.loading,
@@ -48,13 +43,8 @@ void main() {
           'Emits loading state and success state respectively if leave counts are fetched successfully from firestore',
           () {
         when(leaveService.getUserUsedLeaves('id')).thenAnswer((_) async => 10);
-        when(userStateNotifier.currentSpaceId).thenReturn('space-id');
-        when(spaceService.getPaidLeaves(spaceId: 'space-id'))
-            .thenAnswer((_) async => 12);
-
         AdminLeaveDetailsState successState = const AdminLeaveDetailsState(
             adminReply: '',
-            paidLeaveCount: 12,
             usedLeaves: 10,
             error: null,
             actionStatus: Status.initial,
@@ -67,13 +57,9 @@ void main() {
       test(
           'Emits loading state and error state if exception is thrown from any cause',
           () {
-        when(leaveService.getUserUsedLeaves('id')).thenAnswer((_) async => 10);
-        when(userStateNotifier.currentSpaceId).thenReturn('space-id');
-        when(spaceService.getPaidLeaves(spaceId: 'space-id'))
-            .thenThrow(Exception(firestoreFetchDataError));
+        when(leaveService.getUserUsedLeaves('id')).thenThrow(Exception('error'));
         AdminLeaveDetailsState errorState = const AdminLeaveDetailsState(
             adminReply: '',
-            paidLeaveCount: 0,
             usedLeaves: 0,
             error: firestoreFetchDataError,
             actionStatus: Status.initial,
@@ -88,7 +74,6 @@ void main() {
       AdminLeaveDetailsState responseLoadingState =
           const AdminLeaveDetailsState(
               adminReply: '',
-              paidLeaveCount: 0,
               usedLeaves: 0,
               actionStatus: Status.loading,
               leaveCountStatus: Status.initial,
@@ -192,7 +177,6 @@ void main() {
             leaveId: 'leave-id'));
         AdminLeaveDetailsState errorState = const AdminLeaveDetailsState(
             adminReply: '',
-            paidLeaveCount: 0,
             usedLeaves: 0,
             error: firestoreFetchDataError,
             actionStatus: Status.error);

--- a/test/unit_test/admin/member/detail/employee_detail_bloc_test.dart
+++ b/test/unit_test/admin/member/detail/employee_detail_bloc_test.dart
@@ -114,7 +114,6 @@ void main() {
           EmployeeDetailLoadedState loadedState = EmployeeDetailLoadedState(
               employee: employee,
               timeOffRatio: 10 / 12,
-              paidLeaves: 12,
               usedLeaves: 10);
           expectLater(employeeDetailBloc.stream,
               emitsInOrder([EmployeeDetailLoadingState(), loadedState]));

--- a/test/unit_test/user/leaves/leaves_screen/bloc/leave_count/user_leave_count_bloc_test.dart
+++ b/test/unit_test/user/leaves/leaves_screen/bloc/leave_count/user_leave_count_bloc_test.dart
@@ -22,7 +22,6 @@ void main() {
   UserLeaveCountState loadingState = const UserLeaveCountState(
       status: Status.loading,
       used: 0,
-      totalLeaves: 0,
       leavePercentage: 0,
       error: null);
 
@@ -49,7 +48,6 @@ void main() {
           const UserLeaveCountState(
               status: Status.initial,
               used: 0,
-              totalLeaves: 0,
               leavePercentage: 0,
               error: null));
     });
@@ -68,7 +66,6 @@ void main() {
       const UserLeaveCountState successState = UserLeaveCountState(
           status: Status.success,
           used: 7,
-          totalLeaves: 12,
           leavePercentage: 7 / 12,
           error: null);
       expectLater(userLeaveCountBloc.stream,
@@ -87,7 +84,6 @@ void main() {
       const UserLeaveCountState errorState = UserLeaveCountState(
           status: Status.success,
           used: 0,
-          totalLeaves: 0,
           leavePercentage: 0,
           error: firestoreFetchDataError);
       expectLater(


### PR DESCRIPTION
### Purpose
Show only used leave count if paid leave count is 0

### Summary of Changes
Show only used leave count if paid leave count is 0

### Conformity
- [x] Followed [git guidelines](https://github.com/canopas/flutter-developer-roadmap/blob/main/GitGuideline.md) for creating commit messages and Pull Request guidelines.
- [x] Self-approved the PR - reviewed the PR as a reviewer and gave it self-approval if everything is ok. If not, made the required changes.
- [x] Ensured that the PR satisfies all specified requirements in the ticket, including bug fixes and new features.
- [x] Provided test steps, including steps to reproduce the issue or test the new functionality, ensuring other team members can verify the changes.
- [x] Added/Updated proper code comments to make it easy-to-understand for other developers.
- [x] Reused code (if the same code was written twice, made it common and reused it at both places).
- [x] Removed unused or commented code if not required.
- [x] Ensured proper Dart naming conventions were used for variables, classes, and methods.
- [x] Localized user-facing strings.
- [x] Included screenshots/videos of behavior changes: Provided visual evidence of any changes to UI or behavior for easier review and understanding in the PR description.
- [x] Implemented proper error handling: Ensured that the code anticipated and handled potential errors and edge cases gracefully.
- [x] Avoided introducing technical debt: If the PR introduces technical debt, created and linked appropriate tickets for future resolution.
- [x] Included relevant unit tests: Wrote unit tests that focused on testing behavior and functionality, rather than merely covering lines of code.
- [x] Ensured code was performant and scalable: Verified that the changes did not introduce performance issues or bottlenecks and could scale as needed.
- [x] Ensured comments were up-to-date and relevant to the code to describe complex logic and to add understanding for other developers.
- [x] Marked the PR as ready before submitting it for review.

