### PR TITLE
Fix join space infinite loading on web

### DIFF
--- a/lib/data/bloc/user_state/user_controller_state.dart
+++ b/lib/data/bloc/user_state/user_controller_state.dart
@@ -4,9 +4,9 @@ import 'package:projectunity/data/provider/user_state.dart';
 enum StateController { initial, enable, disable }
 
 class UserControllerState extends Equatable {
-  final UserState userState;
+  final UserState? userState;
 
-  const UserControllerState({required this.userState});
+  const UserControllerState({ this.userState});
 
   @override
   List<Object?> get props => [userState];

--- a/lib/data/bloc/user_state/user_state_controller_bloc.dart
+++ b/lib/data/bloc/user_state/user_state_controller_bloc.dart
@@ -1,11 +1,9 @@
 import 'dart:async';
-
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'package:projectunity/data/bloc/user_state/user_state_controller_event.dart';
 import 'package:projectunity/data/bloc/user_state/user_controller_state.dart';
 import 'package:projectunity/data/model/space/space.dart';
-
 import '../../model/employee/employee.dart';
 import '../../provider/user_state.dart';
 import '../../services/employee_service.dart';
@@ -20,7 +18,7 @@ class UserStateControllerBloc
 
   UserStateControllerBloc(
       this._employeeService, this._userManager, this._spaceService)
-      : super(const UserControllerState(userState: UserState.unknown)) {
+      : super(const UserControllerState()) {
     on<CheckUserStatus>(_updateEmployee);
     on<ClearDataForDisableUser>(_clearData);
   }
@@ -37,7 +35,7 @@ class UserStateControllerBloc
       } else {
         await _userManager.setEmployeeWithSpace(
             space: space, spaceUser: employee, redirect: false);
-        emit(const UserControllerState(userState: UserState.update));
+        emit(const UserControllerState(userState: UserState.authenticated));
       }
     } on Exception {
       emit(const UserControllerState(userState: UserState.unauthenticated));
@@ -46,6 +44,6 @@ class UserStateControllerBloc
 
   Future<void> _clearData(
       ClearDataForDisableUser event, Emitter<UserControllerState> emit) async {
-    _userManager.removeEmployeeWithSpace();
+    await _userManager.removeEmployeeWithSpace();
   }
 }

--- a/lib/data/provider/user_state.dart
+++ b/lib/data/provider/user_state.dart
@@ -6,7 +6,6 @@ import '../model/space/space.dart';
 import '../pref/user_preference.dart';
 
 enum UserState {
-  unknown,
   authenticated,
   unauthenticated,
   spaceJoined,

--- a/lib/ui/admin/home/home_screen/admin_home_screen.dart
+++ b/lib/ui/admin/home/home_screen/admin_home_screen.dart
@@ -60,9 +60,7 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
             context.read<AdminHomeBloc>().add(AdminHomeInitialLoadEvent());
           },
           child: BlocListener<UserStateControllerBloc, UserControllerState>(
-            listenWhen: (previous, current) =>
-                current.userState == UserState.unauthenticated ||
-                current.userState == UserState.update,
+            listenWhen: (previous, current) => previous.userState != current.userState,
             listener: (context, state) {
               if (state.userState == UserState.unauthenticated) {
                 showDialog(
@@ -85,7 +83,7 @@ class _AdminHomeScreenState extends State<AdminHomeScreen> {
                         ],
                       );
                     });
-              } else if (state.userState == UserState.update) {
+              } else if (state.userState == UserState.authenticated) {
                 context.read<AdminHomeBloc>().add(AdminHomeInitialLoadEvent());
                 context
                     .read<WhoIsOutCardBloc>()

--- a/lib/ui/space/join_space/join_space_screen.dart
+++ b/lib/ui/space/join_space/join_space_screen.dart
@@ -95,8 +95,7 @@ class _JoinSpaceScreenState extends State<JoinSpaceScreen> {
                   style: AppFontStyle.bodyLarge),
               const SizedBox(height: 10),
               BlocBuilder<JoinSpaceBloc, JoinSpaceState>(
-                  buildWhen: (previous, current) =>
-                      current.fetchSpaceStatus == Status.success,
+                  buildWhen: (previous, current) => current.fetchSpaceStatus == Status.success  ||  current.fetchSpaceStatus == Status.error,
                   builder: (context, state) {
                     if (state.fetchSpaceStatus == Status.loading ||
                         state.fetchSpaceStatus == Status.initial) {

--- a/lib/ui/user/home/home_screen/user_home_screen.dart
+++ b/lib/ui/user/home/home_screen/user_home_screen.dart
@@ -65,8 +65,7 @@ class _UserHomeScreenState extends State<UserHomeScreen> {
           backgroundColor: AppColors.whiteColor,
           child: BlocListener<UserStateControllerBloc, UserControllerState>(
             listenWhen: (previous, current) =>
-                current.userState == UserState.unauthenticated ||
-                current.userState == UserState.update,
+                current.userState != previous.userState,
             listener: (context, state) {
               if (state.userState == UserState.unauthenticated) {
                 showDialog(
@@ -89,7 +88,7 @@ class _UserHomeScreenState extends State<UserHomeScreen> {
                         ],
                       );
                     });
-              } else if (state.userState == UserState.update) {
+              } else if (state.userState == UserState.authenticated) {
                 context.read<UserHomeBloc>().add(UserHomeFetchLeaveRequest());
                 context
                     .read<WhoIsOutCardBloc>()

--- a/test/unit_test/admin/home/search_member/invite_member_bloc_test.mocks.dart
+++ b/test/unit_test/admin/home/search_member/invite_member_bloc_test.mocks.dart
@@ -143,7 +143,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i7.UserStateNotifier {
   @override
   _i7.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i7.UserState.unknown,
+        returnValue: _i7.UserState.authenticated,
       ) as _i7.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/admin/leaves/application_detail/admin_leave_request_details_bloc_test.mocks.dart
+++ b/test/unit_test/admin/leaves/application_detail/admin_leave_request_details_bloc_test.mocks.dart
@@ -281,7 +281,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i9.UserStateNotifier {
   @override
   _i9.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i9.UserState.unknown,
+        returnValue: _i9.UserState.authenticated,
       ) as _i9.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/admin/member/detail/employee_detail_bloc_test.mocks.dart
+++ b/test/unit_test/admin/member/detail/employee_detail_bloc_test.mocks.dart
@@ -497,7 +497,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i13.UserStateNotifier {
   @override
   _i13.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i13.UserState.unknown,
+        returnValue: _i13.UserState.authenticated,
       ) as _i13.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/admin/member/edit_employee/admin_edit_employee_details_test.mocks.dart
+++ b/test/unit_test/admin/member/edit_employee/admin_edit_employee_details_test.mocks.dart
@@ -233,7 +233,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i8.UserStateNotifier {
   @override
   _i8.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i8.UserState.unknown,
+        returnValue: _i8.UserState.authenticated,
       ) as _i8.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/admin/member/list/employee_list_bloc_test.mocks.dart
+++ b/test/unit_test/admin/member/list/employee_list_bloc_test.mocks.dart
@@ -179,7 +179,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i6.UserStateNotifier {
   @override
   _i6.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i6.UserState.unknown,
+        returnValue: _i6.UserState.authenticated,
       ) as _i6.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/authentication/login/login_bloc_test.mocks.dart
+++ b/test/unit_test/authentication/login/login_bloc_test.mocks.dart
@@ -281,7 +281,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i10.UserStateNotifier {
   @override
   _i10.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i10.UserState.unknown,
+        returnValue: _i10.UserState.authenticated,
       ) as _i10.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/bloc/user_state/user_state_controller_bloc_test.dart
+++ b/test/unit_test/bloc/user_state/user_state_controller_bloc_test.dart
@@ -43,7 +43,7 @@ void main() {
   });
 
   test('Should emit initial state as default state of bloc', () {
-    expect(bloc.state, const UserControllerState(userState: UserState.unknown));
+    expect(bloc.state, const UserControllerState());
   });
 
   test(
@@ -54,7 +54,7 @@ void main() {
         .thenAnswer((_) async => employee);
     when(spaceService.getSpace(space.id)).thenAnswer((_) async => space);
     expectLater(bloc.stream,
-        emits(const UserControllerState(userState: UserState.update)));
+        emits(const UserControllerState(userState: UserState.authenticated)));
     await untilCalled(userStateNotifier.setEmployeeWithSpace(
         space: space, spaceUser: employee, redirect: false));
     verify(userStateNotifier.setEmployeeWithSpace(

--- a/test/unit_test/bloc/user_state/user_state_controller_bloc_test.mocks.dart
+++ b/test/unit_test/bloc/user_state/user_state_controller_bloc_test.mocks.dart
@@ -318,7 +318,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i8.UserStateNotifier {
   @override
   _i8.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i8.UserState.unknown,
+        returnValue: _i8.UserState.authenticated,
       ) as _i8.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/shared/drawer/drawer_test.mocks.dart
+++ b/test/unit_test/shared/drawer/drawer_test.mocks.dart
@@ -222,7 +222,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i9.UserStateNotifier {
   @override
   _i9.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i9.UserState.unknown,
+        returnValue: _i9.UserState.authenticated,
       ) as _i9.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/shared/profile/edit_profile/employee_edit_profile_bloc_test.mocks.dart
+++ b/test/unit_test/shared/profile/edit_profile/employee_edit_profile_bloc_test.mocks.dart
@@ -191,7 +191,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i7.UserStateNotifier {
   @override
   _i7.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i7.UserState.unknown,
+        returnValue: _i7.UserState.authenticated,
       ) as _i7.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/shared/profile/view_profile/view_profile_bloc_test.mocks.dart
+++ b/test/unit_test/shared/profile/view_profile/view_profile_bloc_test.mocks.dart
@@ -57,7 +57,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i4.UserStateNotifier {
   @override
   _i4.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i4.UserState.unknown,
+        returnValue: _i4.UserState.authenticated,
       ) as _i4.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/space/create_space/create_space_bloc_test.mocks.dart
+++ b/test/unit_test/space/create_space/create_space_bloc_test.mocks.dart
@@ -233,7 +233,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i9.UserStateNotifier {
   @override
   _i9.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i9.UserState.unknown,
+        returnValue: _i9.UserState.authenticated,
       ) as _i9.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/space/edit_space_test/edit_space_test.mocks.dart
+++ b/test/unit_test/space/edit_space_test/edit_space_test.mocks.dart
@@ -234,7 +234,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i9.UserStateNotifier {
   @override
   _i9.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i9.UserState.unknown,
+        returnValue: _i9.UserState.authenticated,
       ) as _i9.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/space/join_space/join_space_test.mocks.dart
+++ b/test/unit_test/space/join_space/join_space_test.mocks.dart
@@ -321,7 +321,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i12.UserStateNotifier {
   @override
   _i12.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i12.UserState.unknown,
+        returnValue: _i12.UserState.authenticated,
       ) as _i12.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/user/home/home_screen/user_home_test.mocks.dart
+++ b/test/unit_test/user/home/home_screen/user_home_test.mocks.dart
@@ -70,7 +70,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i5.UserStateNotifier {
   @override
   _i5.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i5.UserState.unknown,
+        returnValue: _i5.UserState.authenticated,
       ) as _i5.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/user/home/leave_calendar/user_leave_calendar_view_bloc/user_leave_calendar_test.mocks.dart
+++ b/test/unit_test/user/home/leave_calendar/user_leave_calendar_view_bloc/user_leave_calendar_test.mocks.dart
@@ -389,7 +389,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i9.UserStateNotifier {
   @override
   _i9.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i9.UserState.unknown,
+        returnValue: _i9.UserState.authenticated,
       ) as _i9.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/user/leaves/apply_leave/apply_leave_bloc_test.mocks.dart
+++ b/test/unit_test/user/leaves/apply_leave/apply_leave_bloc_test.mocks.dart
@@ -270,7 +270,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i8.UserStateNotifier {
   @override
   _i8.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i8.UserState.unknown,
+        returnValue: _i8.UserState.authenticated,
       ) as _i8.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/user/leaves/leaves_screen/bloc/leave_count/user_leave_count_bloc_test.mocks.dart
+++ b/test/unit_test/user/leaves/leaves_screen/bloc/leave_count/user_leave_count_bloc_test.mocks.dart
@@ -268,7 +268,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i8.UserStateNotifier {
   @override
   _i8.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i8.UserState.unknown,
+        returnValue: _i8.UserState.authenticated,
       ) as _i8.UserState);
   @override
   String get employeeId => (super.noSuchMethod(

--- a/test/unit_test/user/leaves/leaves_screen/bloc/leaves/user_leave_bloc_test.mocks.dart
+++ b/test/unit_test/user/leaves/leaves_screen/bloc/leaves/user_leave_bloc_test.mocks.dart
@@ -257,7 +257,7 @@ class MockUserStateNotifier extends _i1.Mock implements _i7.UserStateNotifier {
   @override
   _i7.UserState get state => (super.noSuchMethod(
         Invocation.getter(#state),
-        returnValue: _i7.UserState.unknown,
+        returnValue: _i7.UserState.authenticated,
       ) as _i7.UserState);
   @override
   String get employeeId => (super.noSuchMethod(


### PR DESCRIPTION
### Purpose
 - Fix join space infinite loading

### Summary of Changes
 - Fix join space infinite loading

### Conformity
- [x] Followed [git guidelines](https://github.com/canopas/flutter-developer-roadmap/blob/main/GitGuideline.md) for creating commit messages and Pull Request guidelines.
- [x] Self-approved the PR - reviewed the PR as a reviewer and gave it self-approval if everything is ok. If not, made the required changes.
- [x] Ensured that the PR satisfies all specified requirements in the ticket, including bug fixes and new features.
- [x] Provided test steps, including steps to reproduce the issue or test the new functionality, ensuring other team members can verify the changes.
- [x] Added/Updated proper code comments to make it easy-to-understand for other developers.
- [x] Reused code (if the same code was written twice, made it common and reused it at both places).
- [x] Removed unused or commented code if not required.
- [x] Ensured proper Dart naming conventions were used for variables, classes, and methods.
- [x] Localized user-facing strings.
- [x] Included screenshots/videos of behavior changes: Provided visual evidence of any changes to UI or behavior for easier review and understanding in the PR description.
- [x] Implemented proper error handling: Ensured that the code anticipated and handled potential errors and edge cases gracefully.
- [x] Avoided introducing technical debt: If the PR introduces technical debt, created and linked appropriate tickets for future resolution.
- [x] Included relevant unit tests: Wrote unit tests that focused on testing behavior and functionality, rather than merely covering lines of code.
- [x] Ensured code was performant and scalable: Verified that the changes did not introduce performance issues or bottlenecks and could scale as needed.
- [x] Ensured comments were up-to-date and relevant to the code to describe complex logic and to add understanding for other developers.
- [x] Marked the PR as ready before submitting it for review.

