### PR TITLE
Set leave status const for notification

### DIFF
--- a/lib/data/services/mail_notification_service.dart
+++ b/lib/data/services/mail_notification_service.dart
@@ -30,7 +30,7 @@ class NotificationService {
               body: json.encode({
                 'name': name,
                 "date": getFormatDate(startDate: startDate, endDate: endDate),
-                "status": "pending",
+                "status": LeaveStatus.pending.value,
                 'receiver': receiver,
               }));
       return response.statusCode == 200;
@@ -51,7 +51,7 @@ class NotificationService {
               body: json.encode({
                 "name": name,
                 "date": getFormatDate(startDate: startDate, endDate: endDate),
-                "status": status.name,
+                "status": status.value,
                 "receiver": receiver,
               }));
       return response.statusCode == 200;

--- a/lib/data/services/mail_notification_service.dart
+++ b/lib/data/services/mail_notification_service.dart
@@ -15,11 +15,12 @@ class NotificationService {
 
   @disposeMethod
   Future<void> dispose() async {
-   httpClient.close();
+    httpClient.close();
   }
 
   Future<bool> notifyHRForNewLeave(
       {required String name,
+      required String reason,
       required DateTime startDate,
       required DateTime endDate,
       required String receiver}) async {
@@ -31,6 +32,7 @@ class NotificationService {
                 'name': name,
                 "date": getFormatDate(startDate: startDate, endDate: endDate),
                 "status": LeaveStatus.pending.value,
+                'reason': reason,
                 'receiver': receiver,
               }));
       return response.statusCode == 200;

--- a/lib/ui/user/leaves/apply_leave/bloc/apply_leave_bloc.dart
+++ b/lib/ui/user/leaves/apply_leave/bloc/apply_leave_bloc.dart
@@ -125,6 +125,7 @@ class ApplyLeaveBloc extends Bloc<ApplyLeaveEvent, ApplyLeaveState>
                 name: _userStateNotifier.employee.name,
                 startDate: leaveData.startDate,
                 endDate: leaveData.endDate,
+                reason: leaveData.reason,
                 receiver: notificationEmail);
           }
           emit(state.copyWith(leaveRequestStatus: Status.success));

--- a/test/unit_test/admin/leaves/application_detail/admin_leave_request_details_bloc_test.mocks.dart
+++ b/test/unit_test/admin/leaves/application_detail/admin_leave_request_details_bloc_test.mocks.dart
@@ -572,6 +572,7 @@ class MockNotificationService extends _i1.Mock
   @override
   _i7.Future<bool> notifyHRForNewLeave({
     required String? name,
+    required String? reason,
     required DateTime? startDate,
     required DateTime? endDate,
     required String? receiver,
@@ -582,6 +583,7 @@ class MockNotificationService extends _i1.Mock
           [],
           {
             #name: name,
+            #reason: reason,
             #startDate: startDate,
             #endDate: endDate,
             #receiver: receiver,

--- a/test/unit_test/user/leaves/apply_leave/apply_leave_bloc_test.dart
+++ b/test/unit_test/user/leaves/apply_leave/apply_leave_bloc_test.dart
@@ -340,6 +340,7 @@ void main() {
       when(userStateNotifier.employee).thenReturn(employee);
       when(userStateNotifier.currentSpace).thenReturn(space);
       when(notificationService.notifyHRForNewLeave(
+              reason: 'reason',
               receiver: 'hr@canopas.com',
               name: "dummy",
               startDate: leave.startDate,

--- a/test/unit_test/user/leaves/apply_leave/apply_leave_bloc_test.mocks.dart
+++ b/test/unit_test/user/leaves/apply_leave/apply_leave_bloc_test.mocks.dart
@@ -431,6 +431,7 @@ class MockNotificationService extends _i1.Mock
   @override
   _i6.Future<bool> notifyHRForNewLeave({
     required String? name,
+    required String? reason,
     required DateTime? startDate,
     required DateTime? endDate,
     required String? receiver,
@@ -441,6 +442,7 @@ class MockNotificationService extends _i1.Mock
           [],
           {
             #name: name,
+            #reason: reason,
             #startDate: startDate,
             #endDate: endDate,
             #receiver: receiver,


### PR DESCRIPTION
### Purpose
- Set leave status const for notification

### Summary of Changes
 - Set leave status const for notification

### Conformity

- [x] Followed [git guidelines](https://github.com/canopas/flutter-developer-roadmap/blob/main/GitGuideline.md) for creating commit messages and Pull Request guidelines.
- [x] Self-approved the PR - reviewed the PR as a reviewer and gave it self-approval if everything is ok. If not, made the required changes.
- [x] Ensured that the PR satisfies all specified requirements in the ticket, including bug fixes and new features.
- [x] Provided test steps, including steps to reproduce the issue or test the new functionality, ensuring other team members can verify the changes.
- [x] Added/Updated proper code comments to make it easy-to-understand for other developers.
- [x] Reused code (if the same code was written twice, made it common and reused it at both places).
- [x] Removed unused or commented code if not required.
- [x] Ensured proper Dart naming conventions were used for variables, classes, and methods.
- [x] Localized user-facing strings.
- [x] Included screenshots/videos of behavior changes: Provided visual evidence of any changes to UI or behavior for easier review and understanding in the PR description.
- [x] Implemented proper error handling: Ensured that the code anticipated and handled potential errors and edge cases gracefully.
- [x] Avoided introducing technical debt: If the PR introduces technical debt, created and linked appropriate tickets for future resolution.
- [x] Included relevant unit tests: Wrote unit tests that focused on testing behavior and functionality, rather than merely covering lines of code.
- [x] Ensured code was performant and scalable: Verified that the changes did not introduce performance issues or bottlenecks and could scale as needed.
- [x] Ensured comments were up-to-date and relevant to the code to describe complex logic and to add understanding for other developers.
- [x] Marked the PR as ready before submitting it for review.


