### PR TITLE
Fix other space data shown in who is out card on change space

### DIFF
--- a/lib/data/Repo/employee_repo.dart
+++ b/lib/data/Repo/employee_repo.dart
@@ -11,11 +11,11 @@ import '../services/employee_service.dart';
 class EmployeeRepo {
   final EmployeeService _employeeService;
   final UserStateNotifier _userStateNotifier;
-  final BehaviorSubject<List<Employee>> _employeeController =
-      BehaviorSubject<List<Employee>>();
+  late BehaviorSubject<List<Employee>> _employeeController;
   StreamSubscription<List<Employee>>? _employeeStreamSubscription;
 
   EmployeeRepo(this._employeeService, this._userStateNotifier) {
+    _employeeController = BehaviorSubject<List<Employee>>();
     _employeeStreamSubscription = _employeeService
         .employees(_userStateNotifier.currentSpaceId!)
         .listen((value) {
@@ -38,6 +38,7 @@ class EmployeeRepo {
           .toList());
 
   Future<void> reset() async {
+    _employeeController = BehaviorSubject<List<Employee>>();
     await _employeeStreamSubscription?.cancel();
     _employeeStreamSubscription =
         _employeeService.employees(_userStateNotifier.currentSpaceId!).listen(
@@ -47,13 +48,9 @@ class EmployeeRepo {
     );
   }
 
-  Future<void> cancel() async {
-    await _employeeStreamSubscription?.cancel();
-  }
-
   @disposeMethod
   Future<void> dispose() async {
-    await _employeeStreamSubscription?.cancel();
     await _employeeController.close();
+    await _employeeStreamSubscription?.cancel();
   }
 }

--- a/lib/data/Repo/leave_repo.dart
+++ b/lib/data/Repo/leave_repo.dart
@@ -8,11 +8,11 @@ import 'package:rxdart/rxdart.dart';
 @LazySingleton()
 class LeaveRepo {
   final LeaveService _leaveService;
-  final BehaviorSubject<List<Leave>> _leavesController =
-      BehaviorSubject<List<Leave>>();
+  late BehaviorSubject<List<Leave>> _leavesController;
   StreamSubscription<List<Leave>>? _leavesStreamSubscription;
 
   LeaveRepo(this._leaveService) {
+    _leavesController = BehaviorSubject<List<Leave>>();
     _leavesStreamSubscription = _leaveService.leaves.listen((value) {
       _leavesController.add(value);
     }, onError: (e, s) async {
@@ -38,6 +38,7 @@ class LeaveRepo {
           .toList());
 
   Future<void> reset() async {
+    _leavesController = BehaviorSubject<List<Leave>>();
     await _leavesStreamSubscription?.cancel();
     _leavesStreamSubscription = _leaveService.leaves.listen(
       (value) {
@@ -55,13 +56,9 @@ class LeaveRepo {
   Stream<List<Leave>> userLeaves(String uid) => _leavesController.stream
       .asyncMap((leaves) => leaves.where((leave) => leave.uid == uid).toList());
 
-  Future<void> cancel() async {
-    await _leavesStreamSubscription?.cancel();
-  }
-
   @disposeMethod
   Future<void> dispose() async {
-    await _leavesStreamSubscription?.cancel();
     await _leavesController.close();
+    await _leavesStreamSubscription?.cancel();
   }
 }

--- a/lib/data/provider/user_state.dart
+++ b/lib/data/provider/user_state.dart
@@ -59,8 +59,8 @@ class UserStateNotifier with ChangeNotifier {
   }
 
   Future<void> removeEmployeeWithSpace() async {
-    await getIt<LeaveRepo>().cancel();
-    await getIt<EmployeeRepo>().cancel();
+    await getIt<LeaveRepo>().dispose();
+    await getIt<EmployeeRepo>().dispose();
     await _userPreference.removeSpace();
     await _userPreference.removeEmployee();
     _userState = UserState.authenticated;

--- a/test/unit_test/admin/home/home_screen/admin_home_bloc_test.mocks.dart
+++ b/test/unit_test/admin/home/home_screen/admin_home_bloc_test.mocks.dart
@@ -58,15 +58,6 @@ class MockEmployeeRepo extends _i1.Mock implements _i2.EmployeeRepo {
         returnValueForMissingStub: _i3.Future<void>.value(),
       ) as _i3.Future<void>);
   @override
-  _i3.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-  @override
   _i3.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
@@ -129,15 +120,6 @@ class MockLeaveRepo extends _i1.Mock implements _i5.LeaveRepo {
         ),
         returnValue: _i3.Stream<List<_i6.Leave>>.empty(),
       ) as _i3.Stream<List<_i6.Leave>>);
-  @override
-  _i3.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
   @override
   _i3.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(

--- a/test/unit_test/admin/leaves/leave_screen/admin_leaves_test.mocks.dart
+++ b/test/unit_test/admin/leaves/leave_screen/admin_leaves_test.mocks.dart
@@ -58,15 +58,6 @@ class MockEmployeeRepo extends _i1.Mock implements _i2.EmployeeRepo {
         returnValueForMissingStub: _i3.Future<void>.value(),
       ) as _i3.Future<void>);
   @override
-  _i3.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-  @override
   _i3.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
@@ -129,15 +120,6 @@ class MockLeaveRepo extends _i1.Mock implements _i5.LeaveRepo {
         ),
         returnValue: _i3.Stream<List<_i6.Leave>>.empty(),
       ) as _i3.Stream<List<_i6.Leave>>);
-  @override
-  _i3.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
   @override
   _i3.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(

--- a/test/unit_test/admin/member/employee_leaves/admin_employee_details_leaves_test.mocks.dart
+++ b/test/unit_test/admin/member/employee_leaves/admin_employee_details_leaves_test.mocks.dart
@@ -73,15 +73,6 @@ class MockLeaveRepo extends _i1.Mock implements _i2.LeaveRepo {
         returnValue: _i3.Stream<List<_i4.Leave>>.empty(),
       ) as _i3.Stream<List<_i4.Leave>>);
   @override
-  _i3.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-  @override
   _i3.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,

--- a/test/unit_test/admin/member/list/employee_list_bloc_test.mocks.dart
+++ b/test/unit_test/admin/member/list/employee_list_bloc_test.mocks.dart
@@ -84,15 +84,6 @@ class MockEmployeeRepo extends _i1.Mock implements _i4.EmployeeRepo {
         returnValueForMissingStub: _i5.Future<void>.value(),
       ) as _i5.Future<void>);
   @override
-  _i5.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i5.Future<void>.value(),
-        returnValueForMissingStub: _i5.Future<void>.value(),
-      ) as _i5.Future<void>);
-  @override
   _i5.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,

--- a/test/unit_test/shared/profile/view_profile/view_profile_bloc_test.mocks.dart
+++ b/test/unit_test/shared/profile/view_profile/view_profile_bloc_test.mocks.dart
@@ -218,15 +218,6 @@ class MockEmployeeRepo extends _i1.Mock implements _i8.EmployeeRepo {
         returnValueForMissingStub: _i4.Future<void>.value(),
       ) as _i4.Future<void>);
   @override
-  _i4.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
   _i4.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,

--- a/test/unit_test/shared/who_is_out_card/who_is_out_card_test.mocks.dart
+++ b/test/unit_test/shared/who_is_out_card/who_is_out_card_test.mocks.dart
@@ -75,15 +75,6 @@ class MockLeaveRepo extends _i1.Mock implements _i2.LeaveRepo {
         returnValue: _i3.Stream<List<_i4.Leave>>.empty(),
       ) as _i3.Stream<List<_i4.Leave>>);
   @override
-  _i3.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-  @override
   _i3.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,
@@ -124,15 +115,6 @@ class MockEmployeeRepo extends _i1.Mock implements _i5.EmployeeRepo {
   _i3.Future<void> reset() => (super.noSuchMethod(
         Invocation.method(
           #reset,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-  @override
-  _i3.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
           [],
         ),
         returnValue: _i3.Future<void>.value(),

--- a/test/unit_test/user/home/home_screen/user_home_test.mocks.dart
+++ b/test/unit_test/user/home/home_screen/user_home_test.mocks.dart
@@ -236,15 +236,6 @@ class MockLeaveRepo extends _i1.Mock implements _i8.LeaveRepo {
         returnValue: _i4.Stream<List<_i9.Leave>>.empty(),
       ) as _i4.Stream<List<_i9.Leave>>);
   @override
-  _i4.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
   _i4.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,

--- a/test/unit_test/user/leaves/leaves_screen/bloc/leaves/user_leave_bloc_test.mocks.dart
+++ b/test/unit_test/user/leaves/leaves_screen/bloc/leaves/user_leave_bloc_test.mocks.dart
@@ -88,15 +88,6 @@ class MockLeaveRepo extends _i1.Mock implements _i3.LeaveRepo {
         returnValue: _i4.Stream<List<_i5.Leave>>.empty(),
       ) as _i4.Stream<List<_i5.Leave>>);
   @override
-  _i4.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i4.Future<void>.value(),
-        returnValueForMissingStub: _i4.Future<void>.value(),
-      ) as _i4.Future<void>);
-  @override
   _i4.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,

--- a/test/unit_test/user/members/list/user_employees_test.mocks.dart
+++ b/test/unit_test/user/members/list/user_employees_test.mocks.dart
@@ -56,15 +56,6 @@ class MockEmployeeRepo extends _i1.Mock implements _i2.EmployeeRepo {
         returnValueForMissingStub: _i3.Future<void>.value(),
       ) as _i3.Future<void>);
   @override
-  _i3.Future<void> cancel() => (super.noSuchMethod(
-        Invocation.method(
-          #cancel,
-          [],
-        ),
-        returnValue: _i3.Future<void>.value(),
-        returnValueForMissingStub: _i3.Future<void>.value(),
-      ) as _i3.Future<void>);
-  @override
   _i3.Future<void> dispose() => (super.noSuchMethod(
         Invocation.method(
           #dispose,


### PR DESCRIPTION
### Purpose

Fix other space data shown in who is out card on change space

### Summary of Changes

Fix other space data shown in who is out card on change space

### Test steps

Run flutter test 

### Conformity
- [x] Followed [git guidelines](https://github.com/canopas/flutter-developer-roadmap/blob/main/GitGuideline.md) for creating commit messages and Pull Request guidelines.
- [x] Self-approved the PR - reviewed the PR as a reviewer and gave it self-approval if everything is ok. If not, made the required changes.
- [x] Ensured that the PR satisfies all specified requirements in the ticket, including bug fixes and new features.
- [x] Provided test steps, including steps to reproduce the issue or test the new functionality, ensuring other team members can verify the changes.
- [x] Added/Updated proper code comments to make it easy-to-understand for other developers.
- [x] Reused code (if the same code was written twice, made it common and reused it at both places).
- [x] Removed unused or commented code if not required.
- [x] Ensured proper Dart naming conventions were used for variables, classes, and methods.
- [x] Localized user-facing strings.
- [x] Included screenshots/videos of behavior changes: Provided visual evidence of any changes to UI or behavior for easier review and understanding in the PR description.
- [x] Implemented proper error handling: Ensured that the code anticipated and handled potential errors and edge cases gracefully.
- [x] Avoided introducing technical debt: If the PR introduces technical debt, created and linked appropriate tickets for future resolution.
- [x] Included relevant unit tests: Wrote unit tests that focused on testing behavior and functionality, rather than merely covering lines of code.
- [x] Ensured code was performant and scalable: Verified that the changes did not introduce performance issues or bottlenecks and could scale as needed.
- [x] Ensured comments were up-to-date and relevant to the code to describe complex logic and to add understanding for other developers.
- [x] Marked the PR as ready before submitting it for review.

